### PR TITLE
add `#include <optional>` to crypto-key-rsa-components.h

### DIFF
--- a/cpp/builtins/web/crypto/crypto-key-rsa-components.h
+++ b/cpp/builtins/web/crypto/crypto-key-rsa-components.h
@@ -2,6 +2,7 @@
 #define JS_COMPUTE_RUNTIME_CRYPTO_KEY_RSA_COMPONENTS_H
 #include <string>
 #include <vector>
+#include <optional>
 
 class CryptoKeyRSAComponents final {
 public:


### PR DESCRIPTION
This helps fix the build when using LLVM 17's libc++.