### PR TITLE
Set more weak symbols for runtime layering

### DIFF
--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -57,6 +57,7 @@ using std::chrono::system_clock;
 
 using JS::Value;
 
+__attribute__((weak)))
 bool debug_logging_enabled() { return DEBUG_LOGGING; }
 #define LOG(...)                                                                                   \
   if (debug_logging_enabled()) {                                                                   \

--- a/runtime/js.cpp
+++ b/runtime/js.cpp
@@ -75,6 +75,7 @@ extern "C" bool exports_wasi_cli_run_run() {
   return true;
 }
 
+__attribute__((weak)) 
 int main(int argc, const char *argv[]) {
   printf("Main starting\n");
   return 0;


### PR DESCRIPTION
These new weak symbols enable better runtime layering, and were needed to build against compute runtime.