### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,13 @@ jobs:
 
     - name: Install Wasmtime
       run: |
-        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/${tag}/wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
+        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/${{ matrix.wasmtime }}/wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
         tar xf wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
         echo `pwd`/wasmtime-${{ matrix.wasmtime }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Install Wizer
       run: |
-        curl -LO https://github.com/bytecodealliance/wizer/releases/download/${tag}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
+        curl -LO https://github.com/bytecodealliance/wizer/releases/download/${{ matrix.wasmtime }}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
         tar xf wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
         echo `pwd`/wizer-${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        wasmtime: [v19.0.2]
-        wizer: [v5.0.0]
-        wasm-tools: [v1.203.0]
+        wasmtime: [19.0.2]
+        wizer: [5.0.0]
+        wasm-tools: [1.203.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -42,21 +42,21 @@ jobs:
 
     - name: Install Wasmtime
       run: |
-        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/${{ matrix.wasmtime }}/wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
-        tar xf wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
-        echo `pwd`/wasmtime-${{ matrix.wasmtime }}-x86_64-linux >> $GITHUB_PATH
+        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v${{ matrix.wasmtime }}/wasmtime-v${{ matrix.wasmtime }}-x86_64-linux.tar.xz
+        tar xf wasmtime-v${{ matrix.wasmtime }}-x86_64-linux.tar.xz
+        echo `pwd`/wasmtime-v${{ matrix.wasmtime }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Install Wizer
       run: |
-        curl -LO https://github.com/bytecodealliance/wizer/releases/download/${{ matrix.wizer }}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
-        tar xf wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
-        echo `pwd`/wizer-${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
+        curl -LO https://github.com/bytecodealliance/wizer/releases/download/v${{ matrix.wizer }}/wizer-v${{ matrix.wizer }}-x86_64-linux.tar.xz
+        tar xf wizer-v${{ matrix.wizer }}-x86_64-linux.tar.xz
+        echo `pwd`/wizer-v${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Install Wasm Tools
       run: |
-        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
-        tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
-        echo `pwd`/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
+        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/v${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        tar xf wasm-tools-v${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        echo `pwd`/wasm-tools-v${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Build StarlingMonkey
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,9 @@ jobs:
         cd ..
         cargo install wasmtime-cli
 
+    - name: Install Wizer
+      run: cargo install wizer
+
     - name: Build StarlingMonkey
       run: |
         cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
 
     - name: Install Wasm Tools
       run: |
-        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/v${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
-        tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/v${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.gz
+        tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.gz
         echo `pwd`/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Build StarlingMonkey

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
 
     - name: Install Wasmtime
       run: |
+        cd ..
         cargo install wasmtime-cli
 
     - name: Build StarlingMonkey

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        wasmtime: [v19.0.2]
+        wizer: [v5.0.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -39,11 +41,15 @@ jobs:
 
     - name: Install Wasmtime
       run: |
-        cd ..
-        cargo install wasmtime-cli
+        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/${tag}/wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
+        tar xf wasmtime-${{ matrix.wasmtime }}-x86_64-linux.tar.xz
+        echo `pwd`/wasmtime-${{ matrix.wasmtime }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Install Wizer
-      run: cargo install wizer
+      run: |
+        curl -LO https://github.com/bytecodealliance/wizer/releases/download/${tag}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
+        tar xf wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
+        echo `pwd`/wizer-${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Build StarlingMonkey
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         os: [ubuntu-latest]
         wasmtime: [v19.0.2]
         wizer: [v5.0.0]
+        wasm-tools: [v1.203.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -50,6 +51,12 @@ jobs:
         curl -LO https://github.com/bytecodealliance/wizer/releases/download/${{ matrix.wizer }}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
         tar xf wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
         echo `pwd`/wizer-${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
+
+    - name: Install Wasm Tools
+      run: |
+        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/${{ matrix.wasm-tools }}/wizer-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        echo `pwd`/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Build StarlingMonkey
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,8 @@ jobs:
     - name: Install Wasm Tools
       run: |
         curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/v${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
-        tar xf wasm-tools-v${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
-        echo `pwd`/wasm-tools-v${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
+        tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        echo `pwd`/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
 
     - name: Build StarlingMonkey
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,24 +40,6 @@ jobs:
       with:
         node-version: 'lts/*'
 
-    - name: Install Wasmtime
-      run: |
-        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/v${{ matrix.wasmtime }}/wasmtime-v${{ matrix.wasmtime }}-x86_64-linux.tar.xz
-        tar xf wasmtime-v${{ matrix.wasmtime }}-x86_64-linux.tar.xz
-        echo `pwd`/wasmtime-v${{ matrix.wasmtime }}-x86_64-linux >> $GITHUB_PATH
-
-    - name: Install Wizer
-      run: |
-        curl -LO https://github.com/bytecodealliance/wizer/releases/download/v${{ matrix.wizer }}/wizer-v${{ matrix.wizer }}-x86_64-linux.tar.xz
-        tar xf wizer-v${{ matrix.wizer }}-x86_64-linux.tar.xz
-        echo `pwd`/wizer-v${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
-
-    - name: Install Wasm Tools
-      run: |
-        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/v${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.gz
-        tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.gz
-        echo `pwd`/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
-
     - name: Build StarlingMonkey
       run: |
         cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Install Wasm Tools
       run: |
-        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/${{ matrix.wasm-tools }}/wizer-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
+        curl -LO https://github.com/bytecodealliance/wasm-tools/releases/download/${{ matrix.wasm-tools }}/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
         tar xf wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux.tar.xz
         echo `pwd`/wasm-tools-${{ matrix.wasm-tools }}-x86_64-linux >> $GITHUB_PATH
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        wasmtime: [19.0.2]
-        wizer: [5.0.0]
-        wasm-tools: [1.203.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Install Wizer
       run: |
-        curl -LO https://github.com/bytecodealliance/wizer/releases/download/${{ matrix.wasmtime }}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
+        curl -LO https://github.com/bytecodealliance/wizer/releases/download/${{ matrix.wizer }}/wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
         tar xf wizer-${{ matrix.wizer }}-x86_64-linux.tar.xz
         echo `pwd`/wizer-${{ matrix.wizer }}-x86_64-linux >> $GITHUB_PATH
 

--- a/cmake/wasmtime.cmake
+++ b/cmake/wasmtime.cmake
@@ -1,4 +1,4 @@
-set(WASMTIME_VERSION v16.0.0)
+set(WASMTIME_VERSION v19.0.2)
 set(WASMTIME_URL https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
 CPMAddPackage(NAME wasmtime URL ${WASMTIME_URL} DOWNLOAD_ONLY TRUE)
 set(WASMTIME ${CPM_PACKAGE_wasmtime_SOURCE_DIR}/wasmtime)

--- a/componentize.sh
+++ b/componentize.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+wizer="${WIZER:-wizer}"
+wasm_tools="${WASM_TOOLS:-wasm-tools}"
+
 # Use $2 as output file if provided, otherwise use the input base name with a .wasm extension
 if [ $# -gt 1 ]
 then
@@ -11,5 +14,5 @@ else
   OUT_FILE="${BASENAME%.*}.wasm"
 fi
 
-echo "$1" | WASMTIME_BACKTRACE_DETAILS=1 wizer --allow-wasi --wasm-bulk-memory true --inherit-stdio true --dir "$(dirname "$1")" -o "$OUT_FILE" -- "$(dirname "$0")/starling.wasm"
-wasm-tools component new -v --adapt "wasi_snapshot_preview1=$(dirname "$0")/preview1-adapter.wasm" --output "$OUT_FILE" "$OUT_FILE"
+echo "$1" | WASMTIME_BACKTRACE_DETAILS=1 $wizer --allow-wasi --wasm-bulk-memory true --inherit-stdio true --dir "$(dirname "$1")" -o "$OUT_FILE" -- "$(dirname "$0")/starling.wasm"
+$wasm_tools component new -v --adapt "wasi_snapshot_preview1=$(dirname "$0")/preview1-adapter.wasm" --output "$OUT_FILE" "$OUT_FILE"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 test_component=$1
 test_expectation=$2
 
+wasmtime="${WASMTIME:-wasmtime}"
+
 output_dir=$(dirname $test_expectation)
 
 if [ ! -f $test_component ]; then
@@ -18,7 +20,7 @@ fi
 wasmtime_log="$output_dir/wasmtime.log"
 response_body_log="$output_dir/response.log"
 
-wasmtime serve -S common --addr 0.0.0.0:8181 $test_component 2> "$wasmtime_log" &
+$wasmtime serve -S common --addr 0.0.0.0:8181 $test_component 2> "$wasmtime_log" &
 wasmtime_pid="$!"
 
 function cleanup {

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -17,3 +17,5 @@ function(test TEST_NAME)
 endfunction()
 
 test(smoke)
+
+set_property(TEST smoke PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME}")

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -10,7 +10,7 @@ function(test TEST_NAME)
     add_custom_command(
             OUTPUT test-${TEST_NAME}.wasm
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMAND ${CMAKE_COMMAND} -E env "PATH=${WASM_TOOLS_DIR};${WIZER_DIR};$ENV{PATH}" ${RUNTIME_DIR}/componentize.sh ${CMAKE_SOURCE_DIR}/tests/cases/${TEST_NAME}/${TEST_NAME}.js test-${TEST_NAME}.wasm
+            COMMAND ${CMAKE_COMMAND} -E env "WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools" env "WIZER=${WIZER_DIR}/wizer" ${RUNTIME_DIR}/componentize.sh ${CMAKE_SOURCE_DIR}/tests/cases/${TEST_NAME}/${TEST_NAME}.js test-${TEST_NAME}.wasm
             DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling.wasm
             VERBATIM
     )

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1,6 +1,8 @@
 enable_testing()
 
 find_program(BASH_PROGRAM bash)
+include("wizer")
+include("wasmtime")
 
 function(test TEST_NAME)
     get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)


### PR DESCRIPTION
This should fix the Wasmtime install, which I believe is due to the Rust toolchain lock to version `1.68.3`. In addition adds Wizer and wasm-tools installs.