### PR TITLE
Support builtin modules

### DIFF
--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -38,6 +38,20 @@ public:
   HandleObject global();
 
   /**
+   * Define a new builtin import
+   * 
+   * The enumerable properties of the builtin object are used to construct
+   * a synthetic module namespace for the module.
+   * 
+   * The enumeration and getters are called only on the first import of
+   * the builtin, so that lazy getters can be used to lazily initialize
+   * builtins.
+   * 
+   * Once loaded, the instance is cached and reused as a singleton.
+   */
+  bool define_builtin_import(const char* id, HandleValue builtin);
+
+  /**
    * Treat the top-level script as a module or classic JS script.
    *
    * By default, the engine treats the top-level script as a module.

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -38,7 +38,7 @@ public:
   HandleObject global();
 
   /**
-   * Define a new builtin import
+   * Define a new builtin module
    * 
    * The enumerable properties of the builtin object are used to construct
    * a synthetic module namespace for the module.
@@ -49,7 +49,7 @@ public:
    * 
    * Once loaded, the instance is cached and reused as a singleton.
    */
-  bool define_builtin_import(const char* id, HandleValue builtin);
+  bool define_builtin_module(const char* id, HandleValue builtin);
 
   /**
    * Treat the top-level script as a module or classic JS script.

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -350,6 +350,10 @@ HandleValue api::Engine::script_value() {
 
 void api::Engine::abort(const char *reason) { ::abort(CONTEXT, reason); }
 
+bool api::Engine::define_builtin_import(const char* id, HandleValue builtin) {
+  return scriptLoader->define_builtin_import(id, builtin);
+}
+
 bool api::Engine::eval_toplevel(const char *path, MutableHandleValue result) {
   JSContext *cx = CONTEXT;
   RootedValue ns(cx);

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -350,8 +350,8 @@ HandleValue api::Engine::script_value() {
 
 void api::Engine::abort(const char *reason) { ::abort(CONTEXT, reason); }
 
-bool api::Engine::define_builtin_import(const char* id, HandleValue builtin) {
-  return scriptLoader->define_builtin_import(id, builtin);
+bool api::Engine::define_builtin_module(const char* id, HandleValue builtin) {
+  return scriptLoader->define_builtin_module(id, builtin);
 }
 
 bool api::Engine::eval_toplevel(const char *path, MutableHandleValue result) {

--- a/runtime/script_loader.cpp
+++ b/runtime/script_loader.cpp
@@ -306,7 +306,7 @@ ScriptLoader::ScriptLoader(JSContext *cx, JS::CompileOptions *opts) {
   SetModuleMetadataHook(rt, module_metadata_hook);
 }
 
-bool ScriptLoader::define_builtin_import(const char* id, HandleValue builtin) {
+bool ScriptLoader::define_builtin_module(const char* id, HandleValue builtin) {
   RootedString id_str(CONTEXT, JS_NewStringCopyZ(CONTEXT, id));
   if (!id_str) {
     return false;

--- a/runtime/script_loader.h
+++ b/runtime/script_loader.h
@@ -17,7 +17,7 @@ public:
   ScriptLoader(JSContext* cx, JS::CompileOptions* opts);
   ~ScriptLoader();
 
-  bool define_builtin_import(const char* id, HandleValue builtin);
+  bool define_builtin_module(const char* id, HandleValue builtin);
   void enable_module_mode(bool enable);
   bool load_top_level_script(const char *path, MutableHandleValue result, MutableHandleValue tla_promise);
   bool load_script(JSContext* cx, const char *script_path, JS::SourceText<mozilla::Utf8Unit> &script);

--- a/runtime/script_loader.h
+++ b/runtime/script_loader.h
@@ -17,6 +17,7 @@ public:
   ScriptLoader(JSContext* cx, JS::CompileOptions* opts);
   ~ScriptLoader();
 
+  bool define_builtin_import(const char* id, HandleValue builtin);
   void enable_module_mode(bool enable);
   bool load_top_level_script(const char *path, MutableHandleValue result, MutableHandleValue tla_promise);
   bool load_script(JSContext* cx, const char *script_path, JS::SourceText<mozilla::Utf8Unit> &script);


### PR DESCRIPTION
This adds support for defining builtin modules from JS objects, which are then lazily turned into synthetic modules when imported, based on enumerating the own keys of the object and making those the exports of the synthetic module.

Useful for supporting custom internal APIs without needing to define globals.