### PR TITLE
Native stream layering

### DIFF
--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -25,6 +25,20 @@
 #include "js/experimental/TypedData.h"
 #pragma clang diagnostic pop
 
+namespace builtins::web::streams {
+
+JSObject *NativeStreamSource::stream(JSObject *self) {
+  return web::fetch::RequestOrResponse::body_stream(owner(self));
+}
+
+bool NativeStreamSource::stream_is_body(JSContext *cx, JS::HandleObject stream) {
+  JSObject *stream_source = get_stream_source(cx, stream);
+  return NativeStreamSource::is_instance(stream_source) &&
+         web::fetch::RequestOrResponse::is_instance(owner(stream_source));
+}
+
+} // builtins::web::streams
+
 namespace builtins::web::fetch {
 
 static api::Engine *ENGINE;

--- a/builtins/web/streams/native-stream-source.cpp
+++ b/builtins/web/streams/native-stream-source.cpp
@@ -7,7 +7,6 @@
 
 #include "js/Stream.h"
 
-#include "../fetch/request-response.h"
 #include "native-stream-sink.h"
 #include "native-stream-source.h"
 
@@ -20,10 +19,6 @@ namespace streams {
 JSObject *NativeStreamSource::owner(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
   return &JS::GetReservedSlot(self, Slots::Owner).toObject();
-}
-
-JSObject *NativeStreamSource::stream(JSObject *self) {
-  return web::fetch::RequestOrResponse::body_stream(owner(self));
 }
 
 JS::Value NativeStreamSource::startPromise(JSObject *self) {
@@ -69,12 +64,6 @@ JSObject *NativeStreamSource::get_stream_source(JSContext *cx, JS::HandleObject 
 bool NativeStreamSource::stream_has_native_source(JSContext *cx, JS::HandleObject stream) {
   JSObject *source = get_stream_source(cx, stream);
   return is_instance(source);
-}
-
-bool NativeStreamSource::stream_is_body(JSContext *cx, JS::HandleObject stream) {
-  JSObject *stream_source = get_stream_source(cx, stream);
-  return NativeStreamSource::is_instance(stream_source) &&
-         web::fetch::RequestOrResponse::is_instance(owner(stream_source));
 }
 
 void NativeStreamSource::set_stream_piped_to_ts_writable(JSContext *cx, JS::HandleObject stream,

--- a/builtins/web/streams/transform-stream.cpp
+++ b/builtins/web/streams/transform-stream.cpp
@@ -7,8 +7,8 @@
 
 #include "js/Conversions.h"
 #include "js/Stream.h"
+#include "builtin.h"
 
-#include "../fetch/request-response.h"
 #include "native-stream-sink.h"
 #include "native-stream-source.h"
 #include "transform-stream-default-controller.h"
@@ -277,7 +277,6 @@ JSObject *TransformStream::owner(JSObject *self) {
 
 void TransformStream::set_owner(JSObject *self, JSObject *owner) {
   MOZ_ASSERT(is_instance(self));
-  MOZ_ASSERT(web::fetch::RequestOrResponse::is_instance(owner));
   MOZ_ASSERT(JS::GetReservedSlot(self, TransformStream::Slots::Owner).isUndefined());
   JS::SetReservedSlot(self, TransformStream::Slots::Owner, JS::ObjectValue(*owner));
 }


### PR DESCRIPTION
I'm currently building a custom request and response version against StarlingMonkey streams, which isn't currently working due to this hard dependence. Having the streams builtins include from request and response seems inverted in terms of the desired layering.

This removes that dependence, fixing the build layering for this use case.