### PR TITLE
Use resolved path in stacks

### DIFF
--- a/runtime/script_loader.cpp
+++ b/runtime/script_loader.cpp
@@ -149,8 +149,6 @@ JSObject* module_resolve_hook(JSContext* cx, HandleValue referencingPrivate,
   if (!path) {
     return nullptr;
   }
-  JS::CompileOptions opts(cx, *COMPILE_OPTS);
-  opts.setFileAndLine(strip_base(path.get(), BASE_PATH), 1);
 
   RootedObject info(cx, &referencingPrivate.toObject());
   RootedValue parent_path_val(cx);
@@ -163,6 +161,9 @@ JSObject* module_resolve_hook(JSContext* cx, HandleValue referencingPrivate,
 
   HostString str = core::encode(cx, parent_path_val);
   const char* resolved_path = resolve_path(path.get(), str.ptr.get(), str.len);
+
+  JS::CompileOptions opts(cx, *COMPILE_OPTS);
+  opts.setFileAndLine(strip_base(resolved_path, BASE_PATH), 1);
   return get_module(cx, path.get(), resolved_path, opts);
 }
 


### PR DESCRIPTION
This fixes a bug where stacks contain the relative specifiers in errors like:

```
@./rel-path.js:17:32
app@index.js:69:25
@index.js:53:23
```

where instead it should be `dir/rel-path.js` in the stack.