### PR TITLE
Event loop reworking, timers tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Then tests can be run with `ctest` directly via:
 CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir cmake-build-debug -j8
 ```
 
+Alternative, the integration test server can be directly run with `wasmtime serve` via:
+
+```bash
+wasmtime serve -S common cmake-build-debug/test-server.wasm
+```
+
+Then visit http://0.0.0.0:8080/timers, or any test name and filter of the form `[testName]/[filter]`
+
 5. Using the runtime with other JS applications
 
 The build directory contains a shell script `componentize.sh` that can be used to create components from JS applications. `componentize.sh` takes a single argument, the path to the JS application, and creates a component with a name of the form `[input-file-name].wasm` in the current working directory.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then tests can be run with `ctest` directly via:
 CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir cmake-build-debug -j8
 ```
 
-Alternative, the integration test server can be directly run with `wasmtime serve` via:
+Alternatively, the integration test server can be directly run with `wasmtime serve` via:
 
 ```bash
 wasmtime serve -S common cmake-build-debug/test-server.wasm

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cmake --build cmake-build-debug --target integration-test-server
 Then tests can be run with `ctest` directly via:
 
 ```bash
-CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir cmake-build-debug -j8
+ctest --test-dir cmake-build-debug -j8 --output-on-failure
 ```
 
 Alternatively, the integration test server can be directly run with `wasmtime serve` via:

--- a/builtins/web/fetch/fetch-api.cpp
+++ b/builtins/web/fetch/fetch-api.cpp
@@ -62,11 +62,6 @@ public:
     return true;
   }
 
-  bool ready() override {
-    // TODO(TS): implement
-    return true;
-  }
-
   void trace(JSTracer *trc) override { TraceEdge(trc, &request_, "Request for response future"); }
 };
 

--- a/builtins/web/fetch/fetch_event.cpp
+++ b/builtins/web/fetch/fetch_event.cpp
@@ -42,7 +42,7 @@ void dec_pending_promise_count(JSObject *self) {
   MOZ_ASSERT(count > 0);
   count--;
   if (count == 0)
-    ENGINE->decr_event_loop_lifetime();
+    ENGINE->decr_event_loop_interest();
   JS::SetReservedSlot(self, static_cast<uint32_t>(FetchEvent::Slots::PendingPromiseCount),
                       JS::Int32Value(count));
 }
@@ -159,7 +159,7 @@ bool send_response(host_api::HttpOutgoingResponse *response, JS::HandleObject se
 
 bool start_response(JSContext *cx, JS::HandleObject response_obj, bool streaming) {
   auto generic_response = Response::response_handle(response_obj);
-  host_api::HttpOutgoingResponse* response;
+  host_api::HttpOutgoingResponse *response;
 
   if (generic_response->is_incoming()) {
     auto incoming_response = static_cast<host_api::HttpIncomingResponse *>(generic_response);
@@ -591,8 +591,8 @@ void exports_wasi_http_incoming_handler(exports_wasi_http_incoming_request reque
 
   dispatch_fetch_event(fetch_event, &total_compute);
 
-  // track the fetch event lifetime, which when decremented ends the event loop
-  ENGINE->incr_event_loop_lifetime();
+  // track fetch event interest, which when decremented ends the event loop
+  ENGINE->incr_event_loop_interest();
 
   bool success = ENGINE->run_event_loop();
 

--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -124,11 +124,6 @@ public:
     return true;
   }
 
-  bool ready() override {
-    // TODO(TS): implement
-    return true;
-  }
-
   void trace(JSTracer *trc) override { TraceEdge(trc, &body_source_, "body source for future"); }
 };
 
@@ -186,11 +181,6 @@ public:
   [[nodiscard]] bool cancel(api::Engine *engine) override {
     // TODO(TS): implement
     handle_ = -1;
-    return true;
-  }
-
-  bool ready() override {
-    // TODO(TS): implement
     return true;
   }
 

--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -37,7 +37,6 @@ public:
   }
 
   [[nodiscard]] bool run(api::Engine *engine) override {
-    MOZ_ASSERT(ready());
     JSContext *cx = engine->cx();
 
     const RootedObject callback(cx, callback_);
@@ -68,8 +67,6 @@ public:
     handle_ = -1;
     return true;
   }
-
-  bool ready() override { return host_api::MonotonicClock::now() >= this->deadline_; }
 
   void trace(JSTracer *trc) override {
     TraceEdge(trc, &callback_, "Timer callback");

--- a/host-apis/wasi-0.2.0-rc-2023-10-18/host_api.cpp
+++ b/host-apis/wasi-0.2.0-rc-2023-10-18/host_api.cpp
@@ -95,7 +95,7 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
+size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
   auto count = tasks->size();
   vector<Borrow<Pollable>> handles;
   for (const auto task : *tasks) {
@@ -106,7 +106,10 @@ std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
   bindings_list_u32_t result{nullptr, 0};
   wasi_io_0_2_0_rc_2023_10_18_poll_poll_list(&list, &result);
   MOZ_ASSERT(result.len > 0);
-  return std::vector<size_t>(result.ptr, result.ptr + result.len);
+  const auto ready_index = result.ptr[0];
+  free(result.ptr);
+
+  return ready_index;
 }
 
 namespace host_api {
@@ -548,11 +551,6 @@ public:
   [[nodiscard]] bool cancel(api::Engine *engine) override {
     MOZ_ASSERT_UNREACHABLE("BodyAppendTask's semantics don't allow for cancellation");
     return true;
-  }
-
-  bool ready() override {
-    // TODO(TS): properly implement. This won't ever return `true` right now
-    return state_ == State::Ready;
   }
 
   [[nodiscard]] int32_t id() override {

--- a/host-apis/wasi-0.2.0-rc-2023-10-18/host_api.cpp
+++ b/host-apis/wasi-0.2.0-rc-2023-10-18/host_api.cpp
@@ -95,7 +95,7 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
+std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
   auto count = tasks->size();
   vector<Borrow<Pollable>> handles;
   for (const auto task : *tasks) {
@@ -106,10 +106,7 @@ size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
   bindings_list_u32_t result{nullptr, 0};
   wasi_io_0_2_0_rc_2023_10_18_poll_poll_list(&list, &result);
   MOZ_ASSERT(result.len > 0);
-  const auto ready_index = result.ptr[0];
-  free(result.ptr);
-
-  return ready_index;
+  return std::vector<size_t>(result.ptr, result.ptr + result.len);
 }
 
 namespace host_api {

--- a/host-apis/wasi-0.2.0-rc-2023-12-05/host_api.cpp
+++ b/host-apis/wasi-0.2.0-rc-2023-12-05/host_api.cpp
@@ -99,7 +99,7 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
+std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
   auto count = tasks->size();
   vector<Borrow<Pollable>> handles;
   for (const auto task : *tasks) {
@@ -110,10 +110,7 @@ size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
   bindings_list_u32_t result{nullptr, 0};
   wasi_io_0_2_0_rc_2023_11_10_poll_poll(&list, &result);
   MOZ_ASSERT(result.len > 0);
-  const auto ready_index = result.ptr[0];
-  free(result.ptr);
-
-  return ready_index;
+  return std::vector<size_t>(result.ptr, result.ptr + result.len);
 }
 
 namespace host_api {

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -96,7 +96,7 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
+std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
   auto count = tasks->size();
   vector<Borrow<Pollable>> handles;
   for (const auto task : *tasks) {
@@ -107,10 +107,7 @@ size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
   wasi_io_0_2_0_poll_list_u32_t result{nullptr, 0};
   wasi_io_0_2_0_poll_poll(&list, &result);
   MOZ_ASSERT(result.len > 0);
-  const auto ready_index = result.ptr[0];
-  free(result.ptr);
-
-  return ready_index;
+  return std::vector<size_t>(result.ptr, result.ptr + result.len);
 }
 
 namespace host_api {
@@ -556,11 +553,6 @@ public:
   [[nodiscard]] bool cancel(api::Engine *engine) override {
     MOZ_ASSERT_UNREACHABLE("BodyAppendTask's semantics don't allow for cancellation");
     return true;
-  }
-
-  bool ready() override {
-    // TODO(TS): properly implement. This won't ever return `true` right now
-    return state_ == State::Ready;
   }
 
   [[nodiscard]] int32_t id() override {

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -96,7 +96,7 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
+size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
   auto count = tasks->size();
   vector<Borrow<Pollable>> handles;
   for (const auto task : *tasks) {
@@ -107,7 +107,10 @@ std::vector<size_t> api::AsyncTask::poll(std::vector<api::AsyncTask *> *tasks) {
   wasi_io_0_2_0_poll_list_u32_t result{nullptr, 0};
   wasi_io_0_2_0_poll_poll(&list, &result);
   MOZ_ASSERT(result.len > 0);
-  return std::vector<size_t>(result.ptr, result.ptr + result.len);
+  const auto ready_index = result.ptr[0];
+  free(result.ptr);
+
+  return ready_index;
 }
 
 namespace host_api {

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -62,7 +62,8 @@ public:
   void enable_module_mode(bool enable);
   bool eval_toplevel(const char *path, MutableHandleValue result);
 
-  bool run_event_loop();
+  bool process_jobs();
+  bool process_async_tasks();
 
   /**
    * Get the JS value associated with the top-level script execution -

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -130,10 +130,9 @@ public:
   virtual void trace(JSTracer *trc) = 0;
 
   /**
-   * Poll for completion on the given async tasks
-   * A list of ready task indices is returned
+   * Select for the next available ready task, providing the oldest ready first.
    */
-  static std::vector<size_t> poll(std::vector<AsyncTask *> *handles);
+  static size_t select(std::vector<AsyncTask *> *handles);
 };
 
 } // namespace api

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -134,11 +134,6 @@ public:
    * A list of ready task indices is returned
    */
   static std::vector<size_t> poll(std::vector<AsyncTask *> *handles);
-
-  /**
-   * Returns whether or not the given task is ready
-   */
-  static bool ready(AsyncTask *task);
 };
 
 } // namespace api

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -33,11 +33,6 @@ class AsyncTask;
 
 class Engine {
 
-typedef int Lifetime;
-
-#define LIFETIME_NONE -1;
-#define LIFETIME_ALL -2;
-
 public:
   Engine();
   JSContext *cx();

--- a/include/host_api.h
+++ b/include/host_api.h
@@ -305,7 +305,7 @@ public:
       : incoming(incoming), outgoing(outgoing) {}
 
   Result<uint8_t> pump();
-  bool ready();
+
   bool done();
 };
 

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -417,12 +417,12 @@ bool api::Engine::run_event_loop() {
   return core::EventLoop::run_event_loop(this, 0);
 }
 
-void api::Engine::incr_event_loop_lifetime() {
-  return core::EventLoop::incr_event_loop_lifetime();
+void api::Engine::incr_event_loop_interest() {
+  return core::EventLoop::incr_event_loop_interest();
 }
 
-void api::Engine::decr_event_loop_lifetime() {
-  return core::EventLoop::decr_event_loop_lifetime();
+void api::Engine::decr_event_loop_interest() {
+  return core::EventLoop::decr_event_loop_interest();
 }
 
 bool api::Engine::dump_value(JS::Value val, FILE *fp) { return ::dump_value(CONTEXT, val, fp); }

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -362,18 +362,7 @@ bool api::Engine::eval_toplevel(const char *path, MutableHandleValue result) {
   }
 
   SCRIPT_VALUE.init(cx, ns);
-
-  if (!this->process_jobs()) {
-    return false;
-  }
-  while (this->has_pending_async_tasks()) {
-    if (!this->process_async_tasks()) {
-      return false;
-    }
-    if (!this->process_jobs()) {
-      return false;
-    }
-  }
+  this->run_event_loop();
 
   // TLA rejections during pre-initialization are treated as top-level exceptions.
   // TLA may remain unresolved, in which case it will continue tasks at runtime.
@@ -424,12 +413,16 @@ bool api::Engine::eval_toplevel(const char *path, MutableHandleValue result) {
   return true;
 }
 
-bool api::Engine::process_jobs() {
-  return core::EventLoop::process_jobs(this, 0);
+bool api::Engine::run_event_loop() {
+  return core::EventLoop::run_event_loop(this, 0);
 }
 
-bool api::Engine::process_async_tasks() {
-  return core::EventLoop::process_async_tasks(this, 0);
+void api::Engine::incr_event_loop_lifetime() {
+  return core::EventLoop::incr_event_loop_lifetime();
+}
+
+void api::Engine::decr_event_loop_lifetime() {
+  return core::EventLoop::decr_event_loop_lifetime();
 }
 
 bool api::Engine::dump_value(JS::Value val, FILE *fp) { return ::dump_value(CONTEXT, val, fp); }

--- a/runtime/event_loop.cpp
+++ b/runtime/event_loop.cpp
@@ -67,6 +67,7 @@ bool EventLoop::run_event_loop(api::Engine *engine, double total_compute) {
       exit_event_loop();
       return false;
     }
+    // if there is no interest in the event loop at all, just run one tick
     if (interest_complete()) {
       exit_event_loop();
       return true;
@@ -76,14 +77,10 @@ bool EventLoop::run_event_loop(api::Engine *engine, double total_compute) {
     size_t tasks_size = tasks->size();
     if (tasks_size == 0) {
       exit_event_loop();
-      // if there is no interest in the event loop at all, we always run one tick
-      if (interest_complete()) {
-        return true;
-      } else {
-        fprintf(stderr, "event loop error - both task and job queues are empty, but expected "
-                        "operations did not resolve");
-        return false;
-      }
+      MOZ_ASSERT(!interest_complete());
+      fprintf(stderr, "event loop error - both task and job queues are empty, but expected "
+                      "operations did not resolve");
+      return false;
     }
 
     // Select the next task to run according to event-loop semantics of oldest-first.

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -25,15 +25,14 @@ public:
   static bool has_pending_async_tasks();
 
   /**
-   * Run the event loop until all async tasks have completed.
-   *
-   * Concretely, that means running a loop, whose body does two things:
-   * 1. Run all micro-tasks, i.e. pending Promise reactions
-   * 2. Run the next ready async task
-   *
-   * The loop terminates once both of these steps are null-ops.
+   * Run the micro-tasks / pending Promise reactions
    */
-  static bool run_event_loop(api::Engine *engine, double total_compute);
+  static bool process_jobs(api::Engine *engine, double total_compute);
+  
+  /**
+   * Select on the next async tasks
+   */
+  static bool process_async_tasks(api::Engine *engine, double timeout);
 
   /**
    * Queue a new async task.

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -32,7 +32,7 @@ public:
 
   static void incr_event_loop_interest();
   static void decr_event_loop_interest();
-  
+
   /**
    * Select on the next async tasks
    */

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -25,12 +25,13 @@ public:
   static bool has_pending_async_tasks();
 
   /**
-   * Run the event loop until all lifetimes are complete
+   * Run the event loop until all interests are complete.
+   * See run_event_loop in extension-api.h for the complete description.
    */
   static bool run_event_loop(api::Engine *engine, double total_compute);
 
-  static void incr_event_loop_lifetime();
-  static void decr_event_loop_lifetime();
+  static void incr_event_loop_interest();
+  static void decr_event_loop_interest();
   
   /**
    * Select on the next async tasks

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -25,9 +25,12 @@ public:
   static bool has_pending_async_tasks();
 
   /**
-   * Run the micro-tasks / pending Promise reactions
+   * Run the event loop until all lifetimes are complete
    */
-  static bool process_jobs(api::Engine *engine, double total_compute);
+  static bool run_event_loop(api::Engine *engine, double total_compute);
+
+  static void incr_event_loop_lifetime();
+  static void decr_event_loop_lifetime();
   
   /**
    * Select on the next async tasks

--- a/tests/integration/assert.js
+++ b/tests/integration/assert.js
@@ -1,22 +1,54 @@
 export class AssertionError extends Error {
-  constructor (msg) {
-    super(msg);
+  constructor (message, detail, actual, expected) {
+    let errText = message;
+    if (detail)
+      errText += ` - ${detail}`;
+    if (actual || expected)
+      errText += `\n\nGot:\n\n${JSON.stringify(actual)}\n\nExpected:\n\n${JSON.stringify(expected)}`
+    super(errText);
   }
 }
 
-function fail (check, message, actual, expected) {
-  let errText = check;
-  if (message)
-    errText += ` - ${message}`;
-  if (actual || expected)
-    errText += `\n\nGot:\n\n${JSON.stringify(actual)}\n\nExpected:\n\n${JSON.stringify(expected)}`
-  throw new AssertionError(errText);
+export function assert (assertion, message) {
+  if (!assertion)
+    throw new AssertionError('assertion failed', message);
 }
 
 export function strictEqual (actual, expected, message) {
-  if (actual !== expected) {
-    fail('not strict equal', message, actual, expected);
+  if (actual !== expected)
+    throw new AssertionError('not strict equal', message, actual, expected);
+}
+
+function innerDeepStrictEqual(actual, expected) {
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || expected.length !== actual.length)
+      return false;
+    for (let i = 0; i < expected.length; i++) {
+      if (!innerDeepStrictEqual(actual[i], expected[i]))
+        return false;
+    }
+    return true;
   }
+  else if (typeof expected === 'object' && expected !== null) {
+    if (typeof actual !== 'object' || actual === null)
+      return false;
+    const keys = Object.keys(expected).sort();
+    if (Object.keys(actual).length !== keys.length)
+      return false;
+    for (const key of keys) {
+      if (!innerDeepStrictEqual(actual[key], expected[key]))
+        return false;
+    }
+    return true;
+  }
+  else {
+    return actual === expected;
+  }
+}
+
+export function deepStrictEqual (actual, expected, message) {
+  if (!innerDeepStrictEqual(actual, expected))
+    throw new AssertionError('not deep strict equal', message, actual, expected);
 }
 
 export function throws(func, errorClass, errorMessage) {
@@ -25,15 +57,15 @@ export function throws(func, errorClass, errorMessage) {
   } catch (err) {
     if (errorClass) {
       if (!(err instanceof errorClass)) {
-        return fail(`not expected error instance calling \`${func.toString()}\``, errorMessage, err.name, errorClass.name);
+        throw new AssertionError(`not expected error instance calling \`${func.toString()}\``, errorMessage, err.name, errorClass.name);
       }
     }
     if (errorMessage) {
       if (err.message !== errorMessage) {
-        return fail(`not expected error message calling \`${func.toString()}\``, errorMessage, err.message, errorMessage);
+        throw new AssertionError(`not expected error message calling \`${func.toString()}\``, errorMessage, err.message, errorMessage);
       }
     }
     return;
   }
-  fail(`Expected \`${func.toString()}\` to throw, but it didn't`);
+  throw new AssertionError(`Expected \`${func.toString()}\` to throw, but it didn't`);
 }

--- a/tests/integration/btoa/btoa.js
+++ b/tests/integration/btoa/btoa.js
@@ -1,9 +1,8 @@
 import { serveTest } from '../test-server.js';
 import { strictEqual, throws } from '../assert.js';
 
-export const handler = serveTest(async () => {
-  // btoa
-  {
+export const handler = serveTest(async (t) => {
+  t.test('btoa', () => {
     var everything = "";
     for (var i = 0; i < 256; i++) {
       everything += String.fromCharCode(i);
@@ -291,10 +290,10 @@ export const handler = serveTest(async () => {
     strictEqual(btoa("ý"), "/Q==", `btoa("ý")`);
     strictEqual(btoa("þ"), "/g==", `btoa("þ")`);
     strictEqual(btoa("ÿ"), "/w==", `btoa("ÿ")`);
-  }
+  });
 
   // atob
-  {
+  t.test('atob', () => {
     strictEqual(atob(""), "", `atob("")`);
     strictEqual(atob("abcd"), 'i·\x1D');
     strictEqual(atob(" abcd"), 'i·\x1D');

--- a/tests/integration/btoa/btoa.js
+++ b/tests/integration/btoa/btoa.js
@@ -374,5 +374,5 @@ export const handler = serveTest(async (t) => {
     throws(() => atob(".."));
     throws(() => atob("--"));
     throws(() => atob("__"));
-  }
+  });
 });

--- a/tests/integration/handlers.js
+++ b/tests/integration/handlers.js
@@ -1,1 +1,2 @@
 export { handler as btoa } from './btoa/btoa.js';
+export { handler as timers } from './timers/timers.js';

--- a/tests/integration/test-server.js
+++ b/tests/integration/test-server.js
@@ -10,10 +10,7 @@ export function serveTest (handler) {
     if (filterEquals)
       testFilter = testFilter.slice(1);
 
-    function filter (subtest) {
-      if (filterEquals)
-        return filterEquals ? subtest === testFilter : subtest.includes(testFilter);
-    }
+    const filter = subtest => filterEquals ? subtest === testFilter : subtest.includes(testFilter);
 
     let subtestCnt = 0;
     let curSubtest = null;
@@ -47,7 +44,7 @@ export function serveTest (handler) {
         return new Response(errorPrefix + e.message, { status: 500 });
       return new Response(errorPrefix + `Unexpected error: ${e.message}\n${e.stack}`, { status: 500 });
     }
-    return new Response(`OK ${testName}${curSubtest ? '?' + curSubtest : subtestCnt > 0 ? ` (${subtestCnt} subtests)` : ''}`);
+    return new Response(`OK ${testName}${curSubtest ? '?' + curSubtest : subtestCnt > 0 || testFilter ? ` (${subtestCnt} subtests)` : ''}`);
   };
 }
 

--- a/tests/integration/test-server.js
+++ b/tests/integration/test-server.js
@@ -3,16 +3,51 @@ import { AssertionError } from './assert.js';
 
 export function serveTest (handler) {
   return async function handle (evt) {
-    const testName = new URL(evt.request.url).pathname.slice(1);
+    const url = new URL(evt.request.url);
+    const testName = url.pathname.slice(1);
+    let testFilter = url.search.slice(1);
+    const filterEquals = testFilter[0] === '=';
+    if (filterEquals)
+      testFilter = testFilter.slice(1);
+
+    function filter (subtest) {
+      if (filterEquals)
+        return filterEquals ? subtest === testFilter : subtest.includes(testFilter);
+    }
+
+    let subtestCnt = 0;
+    let curSubtest = null;
     try {
-      await handler();
+      await handler({
+        skip (name) {
+          if (!filter(name))
+            return;
+          console.log(`SKIPPING TEST ${testName}?${name}`);
+        },
+        test (name, subtest) {
+          if (!filter(name))
+            return;
+          curSubtest = name;
+          const maybePromise = subtest();
+          if (maybePromise) {
+            return maybePromise.then(() => {
+              curSubtest = null;
+              subtestCnt++;
+            });
+          } else {
+            curSubtest = null;
+            subtestCnt++;
+          }
+        }
+      });
     }
     catch (e) {
+      const errorPrefix = `Error running test ${testName}${curSubtest ? '?' + curSubtest : ''}\n`;
       if (e instanceof AssertionError)
-        return new Response(e.message, { status: 500 });
-      return new Response(`Unexpected error: ${e.message}\n${e.stack}`, { status: 500 });
+        return new Response(errorPrefix + e.message, { status: 500 });
+      return new Response(errorPrefix + `Unexpected error: ${e.message}\n${e.stack}`, { status: 500 });
     }
-    return new Response(`${testName} OK`);
+    return new Response(`OK ${testName}${curSubtest ? '?' + curSubtest : subtestCnt > 0 ? ` (${subtestCnt} subtests)` : ''}`);
   };
 }
 

--- a/tests/integration/timers/timers.js
+++ b/tests/integration/timers/timers.js
@@ -19,6 +19,19 @@ export const handler = serveTest(async (t) => {
       }, 20);
     });
   });
+  await t.test("setInterval", async () => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        reject(new AssertionError("Expected setInterval to be called 10 times quickly"));
+      }, 1000);
+      let cnt = 0;
+      setInterval(() => {
+        cnt++;
+        if (cnt === 10)
+          resolve();
+      });
+    });
+  });
   t.test("setInterval-exposed-as-global", () => {
     strictEqual(typeof setInterval, "function", `typeof setInterval`);
   });
@@ -124,7 +137,7 @@ export const handler = serveTest(async (t) => {
     }
   });
 
-  t.skip("setInterval-timeout-parameter-not-supplied", () => {
+  t.test("setInterval-timeout-parameter-not-supplied", () => {
     setInterval(function () {});
   });
 
@@ -156,25 +169,25 @@ export const handler = serveTest(async (t) => {
     );
   });
 
-  t.skip("setInterval-timeout-parameter-negative", () => {
+  t.test("setInterval-timeout-parameter-negative", () => {
     setInterval(() => {}, -1);
     setInterval(() => {}, -1.1);
     setInterval(() => {}, Number.MIN_SAFE_INTEGER);
     setInterval(() => {}, Number.MIN_VALUE);
     setInterval(() => {}, -Infinity);
   });
-  t.skip("setInterval-timeout-parameter-positive", () => {
+  t.test("setInterval-timeout-parameter-positive", () => {
     setInterval(() => {}, 1);
     setInterval(() => {}, 1.1);
     setInterval(() => {}, Number.MAX_SAFE_INTEGER);
     setInterval(() => {}, Number.MAX_VALUE);
     setInterval(() => {}, Infinity);
   });
-  t.skip("setInterval-returns-integer", () => {
+  t.test("setInterval-returns-integer", () => {
     let id = setInterval(() => {}, 1);
     deepStrictEqual(typeof id, "number", `typeof id === "number"`);
   });
-  t.skip("setInterval-called-unbound", () => {
+  t.test("setInterval-called-unbound", () => {
     setInterval.call(undefined, () => {}, 1);
   });
 

--- a/tests/integration/timers/timers.js
+++ b/tests/integration/timers/timers.js
@@ -1,0 +1,573 @@
+import { serveTest } from "../test-server.js";
+import { assert, strictEqual, throws, deepStrictEqual } from "../assert.js";
+
+export const handler = serveTest(async (t) => {
+  await t.test("setTimeout", async () => {
+    let first = false;
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        first = true;
+      }, 10);
+      setTimeout(() => {
+        try {
+          assert(first, 'first timeout should trigger first');
+        } catch (e) {
+          reject(e);
+          return;
+        }
+        resolve();
+      }, 20);
+    });
+  });
+  t.test("setInterval-exposed-as-global", () => {
+    strictEqual(typeof setInterval, "function", `typeof setInterval`);
+  });
+  t.test("setInterval-interface", () => {
+    let actual = Reflect.getOwnPropertyDescriptor(globalThis, "setInterval");
+    let expected = {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: globalThis.setInterval,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis, 'setInterval)`
+    );
+
+    strictEqual(
+      typeof globalThis.setInterval,
+      "function",
+      `typeof globalThis.setInterval`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(globalThis.setInterval, "length");
+    expected = {
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.setInterval, 'length')`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(globalThis.setInterval, "name");
+    expected = {
+      value: "setInterval",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.setInterval, 'name')`
+    );
+  });
+
+  t.test("setInterval-called-as-constructor-function", () => {
+    throws(
+      () => {
+        new setInterval();
+      },
+      TypeError,
+      `setInterval is not a constructor`
+    );
+  });
+
+  t.test("setInterval-empty-parameter", () => {
+    throws(
+      () => {
+        setInterval();
+      },
+      TypeError,
+      `setInterval: At least 1 argument required, but only 0 passed`
+    );
+  });
+
+  t.test("setInterval-handler-parameter-not-supplied", () => {
+    throws(
+      () => {
+        setInterval();
+      },
+      TypeError,
+      `setInterval: At least 1 argument required, but only 0 passed`
+    );
+  });
+
+  t.test("setInterval-handler-parameter-not-callable", () => {
+    let non_callable_types = [
+      // Primitive types
+      null,
+      undefined,
+      true,
+      1,
+      1n,
+      "hello",
+      Symbol(),
+      // After primitive types, the only remaining types are Objects and Functions
+      {},
+    ];
+    for (const type of non_callable_types) {
+      throws(
+        () => {
+          setInterval(type);
+          // TODO: Make a TypeError
+        },
+        Error,
+        `First argument to setInterval must be a function`
+      );
+    }
+  });
+
+  t.skip("setInterval-timeout-parameter-not-supplied", () => {
+    setInterval(function () {});
+  });
+
+  // // https://tc39.es/ecma262/#sec-tonumber
+  t.test("setInterval-timeout-parameter-calls-7.1.4-ToNumber", () => {
+    let sentinel;
+    let requestedType;
+    const test = () => {
+      sentinel = Symbol();
+      const timeout = {
+        [Symbol.toPrimitive](type) {
+          requestedType = type;
+          throw sentinel;
+        },
+      };
+      setInterval(function () {}, timeout);
+    };
+    throws(test);
+    try {
+      test();
+    } catch (thrownError) {
+      deepStrictEqual(thrownError, sentinel, "thrownError === sentinel");
+      deepStrictEqual(requestedType, "number", 'requestedType === "number"');
+    }
+    throws(
+      () => setInterval(function () {}, Symbol()),
+      TypeError,
+      `can't convert symbol to number`
+    );
+  });
+
+  t.skip("setInterval-timeout-parameter-negative", () => {
+    setInterval(() => {}, -1);
+    setInterval(() => {}, -1.1);
+    setInterval(() => {}, Number.MIN_SAFE_INTEGER);
+    setInterval(() => {}, Number.MIN_VALUE);
+    setInterval(() => {}, -Infinity);
+  });
+  t.skip("setInterval-timeout-parameter-positive", () => {
+    setInterval(() => {}, 1);
+    setInterval(() => {}, 1.1);
+    setInterval(() => {}, Number.MAX_SAFE_INTEGER);
+    setInterval(() => {}, Number.MAX_VALUE);
+    setInterval(() => {}, Infinity);
+  });
+  t.skip("setInterval-returns-integer", () => {
+    let id = setInterval(() => {}, 1);
+    deepStrictEqual(typeof id, "number", `typeof id === "number"`);
+  });
+  t.skip("setInterval-called-unbound", () => {
+    setInterval.call(undefined, () => {}, 1);
+  });
+
+  t.test("setTimeout-exposed-as-global", () => {
+    deepStrictEqual(typeof setTimeout, "function", `typeof setTimeout`);
+  });
+  t.test("setTimeout-interface", () => {
+    let actual = Reflect.getOwnPropertyDescriptor(globalThis, "setTimeout");
+    let expected = {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: globalThis.setTimeout,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis, 'setTimeout)`
+    );
+
+    deepStrictEqual(
+      typeof globalThis.setTimeout,
+      "function",
+      `typeof globalThis.setTimeout`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, "length");
+    expected = {
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, 'length')`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, "name");
+    expected = {
+      value: "setTimeout",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.setTimeout, 'name')`
+    );
+  });
+  t.test("setTimeout-called-as-constructor-function", () => {
+    throws(
+      () => {
+        new setTimeout();
+      },
+      TypeError,
+      `setTimeout is not a constructor`
+    );
+  });
+  t.test("setTimeout-empty-parameter", () => {
+    throws(
+      () => {
+        setTimeout();
+      },
+      TypeError,
+      `setTimeout: At least 1 argument required, but only 0 passed`
+    );
+  });
+  t.test("setTimeout-handler-parameter-not-supplied", () => {
+    throws(
+      () => {
+        setTimeout();
+      },
+      TypeError,
+      `setTimeout: At least 1 argument required, but only 0 passed`
+    );
+  });
+  t.test("setTimeout-handler-parameter-not-callable", () => {
+    let non_callable_types = [
+      // Primitive types
+      null,
+      undefined,
+      true,
+      1,
+      1n,
+      "hello",
+      Symbol(),
+      // After primitive types, the only remaining types are Objects and Functions
+      {},
+    ];
+    for (const type of non_callable_types) {
+      throws(
+        () => {
+          setTimeout(type);
+          // TODO: Make a TypeError
+        },
+        Error,
+        `First argument to setTimeout must be a function`
+      );
+    }
+  });
+  t.test("setTimeout-timeout-parameter-not-supplied", () => {
+    setTimeout(function () {});
+  });
+  // https://tc39.es/ecma262/#sec-tonumber
+  t.test("setTimeout-timeout-parameter-calls-7.1.4-ToNumber", () => {
+    let sentinel;
+    let requestedType;
+    const test = () => {
+      sentinel = Symbol();
+      const timeout = {
+        [Symbol.toPrimitive](type) {
+          requestedType = type;
+          throw sentinel;
+        },
+      };
+      setTimeout(function () {}, timeout);
+    };
+    throws(test);
+    try {
+      test();
+    } catch (thrownError) {
+      deepStrictEqual(thrownError, sentinel, "thrownError === sentinel");
+      deepStrictEqual(requestedType, "number", 'requestedType === "number"');
+    }
+    throws(
+      () => setTimeout(function () {}, Symbol()),
+      TypeError,
+      `can't convert symbol to number`
+    );
+  });
+
+  t.test("setTimeout-timeout-parameter-negative", () => {
+    setTimeout(() => {}, -1);
+    setTimeout(() => {}, -1.1);
+    setTimeout(() => {}, Number.MIN_SAFE_INTEGER);
+    setTimeout(() => {}, Number.MIN_VALUE);
+    setTimeout(() => {}, -Infinity);
+  });
+  t.test("setTimeout-timeout-parameter-positive", () => {
+    setTimeout(() => {}, 1);
+    setTimeout(() => {}, 1.1);
+    setTimeout(() => {}, Number.MAX_SAFE_INTEGER);
+    setTimeout(() => {}, Number.MAX_VALUE);
+    setTimeout(() => {}, Infinity);
+  });
+  t.test("setTimeout-returns-integer", () => {
+    let id = setTimeout(() => {}, 1);
+    deepStrictEqual(typeof id, "number", `typeof id === "number"`);
+  });
+  t.test("setTimeout-called-unbound", () => {
+    setTimeout.call(undefined, () => {}, 1);
+  });
+
+  t.test("clearInterval-exposed-as-global", () => {
+    deepStrictEqual(typeof clearInterval, "function", `typeof clearInterval`);
+  });
+  t.test("clearInterval-interface", () => {
+    let actual = Reflect.getOwnPropertyDescriptor(globalThis, "clearInterval");
+    let expected = {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: globalThis.clearInterval,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis, 'clearInterval)`
+    );
+
+    deepStrictEqual(
+      typeof globalThis.clearInterval,
+      "function",
+      `typeof globalThis.clearInterval`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(
+      globalThis.clearInterval,
+      "length"
+    );
+    expected = {
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, 'length')`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, "name");
+    expected = {
+      value: "clearInterval",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.clearInterval, 'name')`
+    );
+  });
+  t.test("clearInterval-called-as-constructor-function", () => {
+    throws(
+      () => {
+        new clearInterval();
+      },
+      TypeError,
+      `clearInterval is not a constructor`
+    );
+  });
+  t.test("clearInterval-id-parameter-not-supplied", () => {
+    throws(
+      () => {
+        clearInterval();
+      },
+      TypeError,
+      `clearInterval: At least 1 argument required, but only 0 passed`
+    );
+  });
+  // https://tc39.es/ecma262/#sec-tonumber
+  t.test("clearInterval-id-parameter-calls-7.1.4-ToNumber", () => {
+    let sentinel;
+    let requestedType;
+    const test = () => {
+      sentinel = Symbol();
+      const timeout = {
+        [Symbol.toPrimitive](type) {
+          requestedType = type;
+          throw sentinel;
+        },
+      };
+      clearInterval(timeout);
+    };
+    throws(test);
+    try {
+      test();
+    } catch (thrownError) {
+      deepStrictEqual(thrownError, sentinel, "thrownError === sentinel");
+      deepStrictEqual(requestedType, "number", 'requestedType === "number"');
+    }
+    throws(
+      () => clearInterval(Symbol()),
+      TypeError,
+      `can't convert symbol to number`
+    );
+  });
+
+  t.test("clearInterval-id-parameter-negative", () => {
+    clearInterval(-1);
+    clearInterval(-1.1);
+    clearInterval(Number.MIN_SAFE_INTEGER);
+    clearInterval(Number.MIN_VALUE);
+    clearInterval(-Infinity);
+  });
+  t.test("clearInterval-id-parameter-positive", () => {
+    clearInterval(1);
+    clearInterval(1.1);
+    clearInterval(Number.MAX_SAFE_INTEGER);
+    clearInterval(Number.MAX_VALUE);
+    clearInterval(Infinity);
+  });
+  t.test("clearInterval-returns-undefined", () => {
+    let result = clearInterval(1);
+    deepStrictEqual(typeof result, "undefined", `typeof result === "undefined"`);
+  });
+  t.test("clearInterval-called-unbound", () => {
+    clearInterval.call(undefined, 1);
+  });
+
+  t.test("clearTimeout-exposed-as-global", () => {
+    deepStrictEqual(typeof clearTimeout, "function", `typeof clearTimeout`);
+  });
+  t.test("clearTimeout-interface", () => {
+    let actual = Reflect.getOwnPropertyDescriptor(globalThis, "clearTimeout");
+    let expected = {
+      writable: true,
+      enumerable: true,
+      configurable: true,
+      value: globalThis.clearTimeout,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis, 'clearTimeout)`
+    );
+
+    deepStrictEqual(
+      typeof globalThis.clearTimeout,
+      "function",
+      `typeof globalThis.clearTimeout`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(
+      globalThis.clearTimeout,
+      "length"
+    );
+    expected = {
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, 'length')`
+    );
+
+    actual = Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, "name");
+    expected = {
+      value: "clearTimeout",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    };
+    deepStrictEqual(
+      actual,
+      expected,
+      `Reflect.getOwnPropertyDescriptor(globalThis.clearTimeout, 'name')`
+    );
+  });
+  t.test("clearTimeout-called-as-constructor-function", () => {
+    throws(
+      () => {
+        new clearTimeout();
+      },
+      TypeError,
+      `clearTimeout is not a constructor`
+    );
+  });
+  t.test("clearTimeout-id-parameter-not-supplied", () => {
+    throws(
+      () => {
+        clearTimeout();
+      },
+      TypeError,
+      `clearTimeout: At least 1 argument required, but only 0 passed`
+    );
+  });
+  // https://tc39.es/ecma262/#sec-tonumber
+  t.test("clearTimeout-id-parameter-calls-7.1.4-ToNumber", () => {
+    let sentinel;
+    let requestedType;
+    const test = () => {
+      sentinel = Symbol();
+      const timeout = {
+        [Symbol.toPrimitive](type) {
+          requestedType = type;
+          throw sentinel;
+        },
+      };
+      clearTimeout(timeout);
+    };
+    throws(test);
+    try {
+      test();
+    } catch (thrownError) {
+      deepStrictEqual(thrownError, sentinel, "thrownError === sentinel");
+      deepStrictEqual(requestedType, "number", 'requestedType === "number"');
+    }
+    throws(
+      () => clearTimeout(Symbol()),
+      TypeError,
+      `can't convert symbol to number`
+    );
+  });
+
+  t.test("clearTimeout-id-parameter-negative", () => {
+    clearTimeout(-1);
+    clearTimeout(-1.1);
+    clearTimeout(Number.MIN_SAFE_INTEGER);
+    clearTimeout(Number.MIN_VALUE);
+    clearTimeout(-Infinity);
+  });
+  t.test("clearTimeout-id-parameter-positive", () => {
+    clearTimeout(1);
+    clearTimeout(1.1);
+    clearTimeout(Number.MAX_SAFE_INTEGER);
+    clearTimeout(Number.MAX_VALUE);
+    clearTimeout(Infinity);
+  });
+  t.test("clearTimeout-returns-undefined", () => {
+    let result = clearTimeout(1);
+    deepStrictEqual(typeof result, "undefined", `typeof result === "undefined"`);
+  });
+  t.test("clearTimeout-called-unbound", () => {
+    clearTimeout.call(undefined, 1);
+  });
+});

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -8,7 +8,7 @@ function(test_e2e TEST_NAME)
     get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)
     add_test(${TEST_NAME} ${BASH_PROGRAM} ${CMAKE_SOURCE_DIR}/tests/test.sh ${RUNTIME_DIR} ${CMAKE_SOURCE_DIR}/tests/e2e/${TEST_NAME})
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
-    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 30)
+    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 120)
 endfunction()
 
 add_custom_target(integration-test-server DEPENDS test-server.wasm)
@@ -26,7 +26,7 @@ function(test_integration TEST_NAME)
 
     add_test(${TEST_NAME} ${BASH_PROGRAM} ${CMAKE_SOURCE_DIR}/tests/test.sh ${RUNTIME_DIR} ${CMAKE_SOURCE_DIR}/tests/integration/${TEST_NAME} ${RUNTIME_DIR}/test-server.wasm ${TEST_NAME})
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
-    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 30)
+    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 120)
 endfunction()
 
 test_e2e(smoke)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -10,6 +10,8 @@ function(test_e2e TEST_NAME)
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
 endfunction()
 
+add_custom_target(integration-test-server DEPENDS test-server.wasm)
+
 function(test_integration TEST_NAME)
     get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)
 
@@ -20,7 +22,6 @@ function(test_integration TEST_NAME)
         DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling.wasm
         VERBATIM
     )
-    add_custom_target(integration-test-server DEPENDS test-server.wasm)
 
     add_test(${TEST_NAME} ${BASH_PROGRAM} ${CMAKE_SOURCE_DIR}/tests/test.sh ${RUNTIME_DIR} ${CMAKE_SOURCE_DIR}/tests/integration/${TEST_NAME} ${RUNTIME_DIR}/test-server.wasm ${TEST_NAME})
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
@@ -33,3 +34,4 @@ test_e2e(tla-err)
 test_e2e(tla-runtime-resolve)
 
 test_integration(btoa)
+test_integration(timers)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -8,6 +8,7 @@ function(test_e2e TEST_NAME)
     get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)
     add_test(${TEST_NAME} ${BASH_PROGRAM} ${CMAKE_SOURCE_DIR}/tests/test.sh ${RUNTIME_DIR} ${CMAKE_SOURCE_DIR}/tests/e2e/${TEST_NAME})
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
+    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 30)
 endfunction()
 
 add_custom_target(integration-test-server DEPENDS test-server.wasm)
@@ -25,6 +26,7 @@ function(test_integration TEST_NAME)
 
     add_test(${TEST_NAME} ${BASH_PROGRAM} ${CMAKE_SOURCE_DIR}/tests/test.sh ${RUNTIME_DIR} ${CMAKE_SOURCE_DIR}/tests/integration/${TEST_NAME} ${RUNTIME_DIR}/test-server.wasm ${TEST_NAME})
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
+    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 30)
 endfunction()
 
 test_e2e(smoke)


### PR DESCRIPTION
This PR reworks the event loop and adds integration tests for the timers builtins.

The `run_event_loop` function is extended to support `incr_event_loop_lifetime` and `decr_event_loop_lifetime` calls which determine how long the event loop lifetime should run for, and when this is zero only a single jobs processing is done.

This PR also updates the task class to support `poll` instead of `select` and makes `ready` a static method.

Resolves https://github.com/bytecodealliance/StarlingMonkey/issues/37, https://github.com/bytecodealliance/StarlingMonkey/issues/39.