### PR TITLE
Allow specifying dependencies from subprojects

### DIFF
--- a/cmake/add_builtin.cmake
+++ b/cmake/add_builtin.cmake
@@ -11,11 +11,11 @@ function(add_builtin)
         set(NS ${NS}::${NAME})
         set(DEFAULT_ENABLE ON)
     else()
-        cmake_parse_arguments(PARSE_ARGV 1 "" "DISABLED_BY_DEFAULT" "" "SRC;LINK_LIBS;INCLUDE_DIRS")
+        cmake_parse_arguments(PARSE_ARGV 1 "" "DISABLED_BY_DEFAULT" "" "SRC;INCLUDE_DIRS;DEPENDENCIES")
         list(GET ARGN 0 NS)
         set(SRC ${_SRC})
-        set(LINK_LIBS ${_LINK_LIBS})
         set(INCLUDE_DIRS ${_INCLUDE_DIRS})
+        set(DEPENDENCIES ${_DEPENDENCIES})
         if (_DISABLED_BY_DEFAULT)
             set(DEFAULT_ENABLE OFF)
         else()
@@ -47,9 +47,46 @@ function(add_builtin)
     message(STATUS "Adding builtin ${DESCRIPTION}")
 
     add_library(${LIB_NAME} STATIC ${SRC})
-    target_link_libraries(${LIB_NAME} PRIVATE spidermonkey extension_api ${LINK_LIBS})
+
+    if (DEPENDENCIES)
+        message(VERBOSE "${LIB_NAME} depends on ${DEPENDENCIES}")
+
+        add_dependencies(${LIB_NAME} ${DEPENDENCIES})
+
+        foreach(DEPENDENCY IN ITEMS ${DEPENDENCIES})
+            get_target_property(TYPE ${DEPENDENCY} TYPE)
+            if(NOT ${TYPE} MATCHES "UTILITY")
+                # A built-in can either depend on libraries implicitly
+                # linked by StarlingMonkey (i.e. depending on OpenSSL
+                # for your built-in when it only needs OpenSSL::Crypto),
+                # or on a library target.
+                target_link_libraries(${LIB_NAME} PRIVATE ${DEPENDENCY})
+            endif()
+
+            # If a built-in requires a sub-dependency, e.g. the OpenSSL
+            # crypto library, we need to build the OpenSSL dependency
+            # first.
+            # The base name for the dependency is also how we're going
+            # to find the includes.
+            string(FIND "${DEPENDENCY}" "::" COLON_COLON)
+            if(COLON_COLON GREATER_EQUAL 0)
+                string(SUBSTRING "${DEPENDENCY}" 0 COLON_COLON DEPENDENCY)
+            endif()
+
+            # Not all dependencies will have their include files in this
+            # location, but we can't, at this point, check if it exists,
+            # because this code runs at configure time and this directory
+            # will be created during compilation time.  This, however,
+            # doesn't cause compilation issues.
+            target_include_directories(${LIB_NAME}
+                       PRIVATE ${CMAKE_BINARY_DIR}/deps/${DEPENDENCY}/include)
+        endforeach()
+    endif ()
+
+    target_link_libraries(${LIB_NAME} PRIVATE spidermonkey extension_api)
     target_link_libraries(builtins PRIVATE ${LIB_NAME})
     target_include_directories(${LIB_NAME} PRIVATE ${INCLUDE_DIRS})
+
     file(APPEND $CACHE{INSTALL_BUILTINS} "NS_DEF(${NS})\n")
     return(PROPAGATE LIB_NAME)
 endfunction()

--- a/cmake/add_builtin.cmake
+++ b/cmake/add_builtin.cmake
@@ -56,7 +56,7 @@ function(add_builtin)
         foreach(DEPENDENCY IN ITEMS ${DEPENDENCIES})
             get_target_property(TYPE ${DEPENDENCY} TYPE)
             if(NOT ${TYPE} MATCHES "UTILITY")
-                # A built-in might specify a speficic dependency
+                # A built-in might specify a specific dependency
                 # (e.g. "OpenSSL::Crypto").  Ensure that if this dependency
                 # is of the right type (i.e. libraries), this particular
                 # built-in is linked against this library.

--- a/cmake/builtins.cmake
+++ b/cmake/builtins.cmake
@@ -77,7 +77,7 @@ add_builtin(
     builtins::web::fetch::fetch_event
     SRC
         builtins/web/fetch/fetch_event.cpp
-    LINK_LIBS
+    DEPENDENCIES
         host_api
     INCLUDE_DIRS
         runtime
@@ -93,7 +93,7 @@ add_builtin(
         builtins/web/crypto/crypto-key-rsa-components.cpp
         builtins/web/crypto/json-web-key.cpp
         builtins/web/crypto/subtle-crypto.cpp
-    LINK_LIBS
+    DEPENDENCIES
         OpenSSL::Crypto
         fmt
     INCLUDE_DIRS

--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -1,7 +1,7 @@
 # Based on https://stackoverflow.com/a/72187533
 set(OPENSSL_VERSION 3.0.7)
-set(OPENSSL_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl-src) # default path by CMake
-set(OPENSSL_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl)
+set(OPENSSL_SOURCE_DIR ${CMAKE_BINARY_DIR}/deps-src/OpenSSL)
+set(OPENSSL_INSTALL_DIR ${CMAKE_BINARY_DIR}/deps/OpenSSL)
 set(OPENSSL_INCLUDE_DIR ${OPENSSL_INSTALL_DIR}/include)
 include(ExternalProject)
 ExternalProject_Add(

--- a/runtime/encode.h
+++ b/runtime/encode.h
@@ -2,7 +2,6 @@
 #define JS_COMPUTE_RUNTIME_ENCODE_H
 
 #include "host_api.h"
-#include "rust-url.h"
 
 namespace core {
 


### PR DESCRIPTION
This patch makes it possible for users of the `add_builtins()` CMake function to specify a per-builtin dependency on another target.  This has been used to fix #42.