### PR TITLE
fix: crypto support & tests

### DIFF
--- a/builtins/web/crypto/crypto-algorithm.cpp
+++ b/builtins/web/crypto/crypto-algorithm.cpp
@@ -2,6 +2,7 @@
 #include "openssl/sha.h"
 #include <fmt/format.h>
 #include <iostream>
+#include <openssl/ecdsa.h>
 #include <optional>
 #include <span>
 #include <vector>
@@ -18,6 +19,50 @@ namespace builtins::web::crypto {
 using dom_exception::DOMException;
 
 // namespace {
+
+int numBitsToBytes(int x) { return (x / 8) + (7 + (x % 8)) / 8; }
+
+std::pair<mozilla::UniquePtr<uint8_t[], JS::FreePolicy>, size_t>
+convertToBytesExpand(JSContext *cx, const BIGNUM *bignum, size_t minimumBufferSize) {
+  int length = BN_num_bytes(bignum);
+
+  size_t bufferSize = std::max<size_t>(length, minimumBufferSize);
+  mozilla::UniquePtr<uint8_t[], JS::FreePolicy> bytes{
+      static_cast<uint8_t *>(JS_malloc(cx, bufferSize))};
+
+  size_t paddingLength = bufferSize - length;
+  if (paddingLength > 0) {
+    uint8_t padding = BN_is_negative(bignum) ? 0xFF : 0x00;
+    std::fill_n(bytes.get(), paddingLength, padding);
+  }
+  BN_bn2bin(bignum, bytes.get() + paddingLength);
+  return std::pair<mozilla::UniquePtr<uint8_t[], JS::FreePolicy>, size_t>(std::move(bytes),
+                                                                          bufferSize);
+}
+
+const EVP_MD *createDigestAlgorithm(JSContext *cx, CryptoAlgorithmIdentifier hashIdentifier) {
+  switch (hashIdentifier) {
+  case CryptoAlgorithmIdentifier::MD5: {
+    return EVP_md5();
+  }
+  case CryptoAlgorithmIdentifier::SHA_1: {
+    return EVP_sha1();
+  }
+  case CryptoAlgorithmIdentifier::SHA_256: {
+    return EVP_sha256();
+  }
+  case CryptoAlgorithmIdentifier::SHA_384: {
+    return EVP_sha384();
+  }
+  case CryptoAlgorithmIdentifier::SHA_512: {
+    return EVP_sha512();
+  }
+  default: {
+    DOMException::raise(cx, "NotSupportedError", "NotSupportedError");
+    return nullptr;
+  }
+  }
+}
 
 const EVP_MD *createDigestAlgorithm(JSContext *cx, JS::HandleObject key) {
 
@@ -356,6 +401,30 @@ JS::Result<NamedCurve> toNamedCurve(JSContext *cx, JS::HandleValue value) {
   } else {
     return JS::Result<NamedCurve>(JS::Error());
   }
+}
+
+JS::Result<size_t> curveSize(JSContext *cx, JS::HandleObject key) {
+
+  JS::RootedObject alg(cx, CryptoKey::get_algorithm(key));
+
+  JS::RootedValue namedCurve_val(cx);
+  JS_GetProperty(cx, alg, "namedCurve", &namedCurve_val);
+  auto namedCurve_chars = core::encode(cx, namedCurve_val);
+  if (!namedCurve_chars) {
+    return JS::Result<size_t>(JS::Error());
+  }
+
+  std::string_view namedCurve = namedCurve_chars;
+  if (namedCurve == "P-256") {
+    return 256;
+  } else if (namedCurve == "P-384") {
+    return 384;
+  } else if (namedCurve == "P-521") {
+    return 521;
+  }
+
+  MOZ_ASSERT_UNREACHABLE();
+  return 0;
 }
 
 // This implements the first section of
@@ -747,12 +816,163 @@ JSObject *CryptoAlgorithmHMAC_Sign_Verify::toObject(JSContext *cx) {
 JSObject *CryptoAlgorithmECDSA_Sign_Verify::sign(JSContext *cx, JS::HandleObject key, std::span<uint8_t> data) {
   MOZ_ASSERT(CryptoKey::is_instance(key));
 
-  return nullptr;
+  // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
+  if (CryptoKey::type(key) != CryptoKeyType::Private) {
+    DOMException::raise(cx, "InvalidAccessError", "InvalidAccessError");
+    return nullptr;
+  }
+
+  // 2. Let hashAlgorithm be the hash member of normalizedAlgorithm.
+  const EVP_MD* algorithm = createDigestAlgorithm(cx, this->hashIdentifier);
+  if (!algorithm) {
+    DOMException::raise(cx, "SubtleCrypto.sign: failed to sign", "OperationError");
+    return nullptr;
+  }
+
+  // 3. Let M be the result of performing the digest operation specified by hashAlgorithm using message.
+  auto digestOption = rawDigest(cx, data, algorithm, EVP_MD_size(algorithm));
+  if (!digestOption.has_value()) {
+    DOMException::raise(cx, "OperationError", "OperationError");
+    return nullptr;
+  }
+
+  auto digest = digestOption.value();
+
+  // 4. Let d be the ECDSA private key associated with key.
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  const EC_KEY * ecKey = EVP_PKEY_get0_EC_KEY(CryptoKey::key(key));
+  #pragma clang diagnostic pop
+  if (!ecKey) {
+    DOMException::raise(cx, "SubtleCrypto.verify: failed to verify", "OperationError");
+    return nullptr;
+  }
+
+  // 5. Let params be the EC domain parameters associated with key.
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  auto sig = ECDSA_do_sign(digest.data(), digest.size(), const_cast<EC_KEY*>(ecKey));
+  #pragma clang diagnostic pop
+  if (!sig) {
+    DOMException::raise(cx, "SubtleCrypto.verify: failed to verify", "OperationError");
+    return nullptr;
+  }
+
+  // 6. If the namedCurve attribute of the [[algorithm]] internal slot of key is "P-256", "P-384" or "P-521":
+  //         Perform the ECDSA signing process, as specified in [RFC6090], Section 5.4, with M as the message, using params as the EC domain parameters, and with d as the private key.
+  //         Let r and s be the pair of integers resulting from performing the ECDSA signing process.
+  //         Let result be an empty byte sequence.
+  //         Let n be the smallest integer such that n * 8 is greater than the logarithm to base 2 of the order of the base point of the elliptic curve identified by params.
+  //         Convert r to an octet string of length n and append this sequence of bytes to result.
+  //         Convert s to an octet string of length n and append this sequence of bytes to result.
+  // Otherwise, the namedCurve attribute of the [[algorithm]] internal slot of key is a value specified in an applicable specification:
+  //     Perform the ECDSA signature steps specified in that specification, passing in M, params and d and resulting in result.
+  const BIGNUM* r;
+  const BIGNUM* s;
+  ECDSA_SIG_get0(sig, &r, &s);
+  auto keySize = curveSize(cx, key);
+  if (keySize.isErr()) {
+    return nullptr;
+  }
+
+  size_t keySizeInBytes = numBitsToBytes(keySize.unwrap());
+
+  auto rBytesAndSize = convertToBytesExpand(cx, r, keySizeInBytes);
+  auto *rBytes = rBytesAndSize.first.get();
+  auto rBytesSize = rBytesAndSize.second;
+
+  auto sBytesAndSize = convertToBytesExpand(cx, s, keySizeInBytes);
+  auto *sBytes = sBytesAndSize.first.get();
+  auto sBytesSize = sBytesAndSize.second;
+
+  auto resultSize = rBytesSize + sBytesSize;
+  mozilla::UniquePtr<uint8_t[], JS::FreePolicy> result{
+      static_cast<uint8_t *>(JS_malloc(cx, resultSize))};
+
+  std::memcpy(result.get(), rBytes, rBytesSize);
+  std::memcpy(result.get() + rBytesSize, sBytes, sBytesSize);
+
+  // 7. Return the result of creating an ArrayBuffer containing result.
+  JS::RootedObject buffer(cx, JS::NewArrayBufferWithContents(cx, resultSize, result.get(), JS::NewArrayBufferOutOfMemory::CallerMustFreeMemory));
+  if (!buffer) {
+    // We can be here is the array buffer was too large -- if that was the case then a
+    // JSMSG_BAD_ARRAY_LENGTH will have been created. No other failure scenarios in this path will
+    // create a JS exception and so we need to create one.
+    if (!JS_IsExceptionPending(cx)) {
+      // TODO Rename error to InternalError
+      JS_ReportErrorLatin1(cx, "InternalError");
+    }
+    return nullptr;
+  }
+
+  // `signature` is now owned by `buffer`
+  static_cast<void>(result.release());
+
+  return buffer;
 };
 JS::Result<bool> CryptoAlgorithmECDSA_Sign_Verify::verify(JSContext *cx, JS::HandleObject key, std::span<uint8_t> signature, std::span<uint8_t> data) {
   MOZ_ASSERT(CryptoKey::is_instance(key));
-  DOMException::raise(cx, "SubtleCrypto.verify: failed to verify", "OperationError");
-  return JS::Result<bool>(JS::Error());
+  // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
+  if (CryptoKey::type(key) != CryptoKeyType::Public) {
+    DOMException::raise(cx, "InvalidAccessError", "InvalidAccessError");
+    return JS::Result<bool>(JS::Error());
+  }
+
+  // 2. Let hashAlgorithm be the hash member of normalizedAlgorithm.
+  const EVP_MD* algorithm = createDigestAlgorithm(cx, this->hashIdentifier);
+  if (!algorithm) {
+    DOMException::raise(cx, "SubtleCrypto.verify: failed to verify", "OperationError");
+    return JS::Result<bool>(JS::Error());
+  }
+
+  // 3. Let M be the result of performing the digest operation specified by hashAlgorithm using message.
+  auto digestOption = rawDigest(cx, data, algorithm, EVP_MD_size(algorithm));
+  if (!digestOption.has_value()) {
+    DOMException::raise(cx, "OperationError", "OperationError");
+    return JS::Result<bool>(JS::Error());
+  }
+
+  auto digest = digestOption.value();
+
+  // 4. Let Q be the ECDSA public key associated with key.
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  const EC_KEY * ecKey = EVP_PKEY_get0_EC_KEY(CryptoKey::key(key));
+  #pragma clang diagnostic pop
+  if (!ecKey) {
+    DOMException::raise(cx, "SubtleCrypto.verify: failed to verify", "OperationError");
+    return JS::Result<bool>(JS::Error());
+  }
+
+  // 5. Let params be the EC domain parameters associated with key.
+  // 6. If the namedCurve attribute of the [[algorithm]] internal slot of key is "P-256", "P-384" or "P-521":
+      // Perform the ECDSA verifying process, as specified in RFC6090, Section 5.3, with M as the received message, signature as the received signature and using params as the EC domain parameters, and Q as the public key.
+    // Otherwise, the namedCurve attribute of the [[algorithm]] internal slot of key is a value specified in an applicable specification:
+      // Perform the ECDSA verification steps specified in that specification passing in M, signature, params and Q and resulting in an indication of whether or not the purported signature is valid.
+  auto keySize = curveSize(cx, key);
+  if (keySize.isErr()) {
+    return JS::Result<bool>(JS::Error());
+  }
+
+  size_t keySizeInBytes = numBitsToBytes(keySize.unwrap());
+
+  auto sig = ECDSA_SIG_new();
+  auto r = BN_bin2bn(signature.data(), keySizeInBytes, nullptr);
+  auto s = BN_bin2bn(signature.data() + keySizeInBytes, keySizeInBytes, nullptr);
+
+  if (!ECDSA_SIG_set0(sig, r, s)) {
+    DOMException::raise(cx, "SubtleCrypto.verify: failed to verify", "OperationError");
+    return JS::Result<bool>(JS::Error());
+  }
+
+  // 7. Let result be a boolean with the value true if the signature is valid and the value false otherwise.
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  bool result = ECDSA_do_verify(digest.data(), digest.size(), sig, const_cast<EC_KEY*>(ecKey)) == 1;
+  #pragma clang diagnostic pop
+
+  // 8. Return result.
+  return result;
 };
 JSObject *CryptoAlgorithmECDSA_Sign_Verify::toObject(JSContext *cx) {
   return nullptr;

--- a/tests/integration/assert.js
+++ b/tests/integration/assert.js
@@ -57,7 +57,7 @@ export function throws(func, errorClass, errorMessage) {
   } catch (err) {
     if (errorClass) {
       if (!(err instanceof errorClass)) {
-        throw new AssertionError(`not expected error instance calling \`${func.toString()}\``, errorMessage, err.name, errorClass.name);
+        throw new AssertionError(`not expected error instance calling \`${func.toString()}\``, errorMessage, err.name + ': ' + err.message, errorClass.name);
       }
     }
     if (errorMessage) {
@@ -68,4 +68,23 @@ export function throws(func, errorClass, errorMessage) {
     return;
   }
   throw new AssertionError(`Expected \`${func.toString()}\` to throw, but it didn't`);
+}
+
+export async function rejects(asyncFunc, errorClass, errorMessage) {
+  try {
+    await asyncFunc();
+  } catch (err) {
+    if (errorClass) {
+      if (!(err instanceof errorClass)) {
+        throw new AssertionError(`not expected error instance calling \`${asyncFunc.toString()}\``, errorMessage, err.name + ': ' + err.message, errorClass.name);
+      }
+    }
+    if (errorMessage) {
+      if (err.message !== errorMessage) {
+        throw new AssertionError(`not expected error message calling \`${asyncFunc.toString()}\``, errorMessage, err.message, errorMessage);
+      }
+    }
+    return;
+  }
+  throw new AssertionError(`Expected \`${asyncFunc.toString()}\` to throw, but it didn't`);
 }

--- a/tests/integration/crypto/crypto.js
+++ b/tests/integration/crypto/crypto.js
@@ -1,0 +1,2028 @@
+import { serveTest } from "../test-server.js";
+import { deepStrictEqual, strictEqual, throws, rejects } from "../assert.js";
+
+// From https://www.rfc-editor.org/rfc/rfc7517#appendix-A.1
+const createPublicRsaJsonWebKeyData = () => ({
+  alg: "RS256",
+  e: "AQAB",
+  ext: true,
+  key_ops: ["verify"],
+  kty: "RSA",
+  n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+});
+
+// From https://www.rfc-editor.org/rfc/rfc7517#appendix-A.1
+const createPublicEcdsaJsonWebKeyData = () => ({
+  kty: "EC",
+  crv: "P-256",
+  x: "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+  y: "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+  kid: "1",
+  ext: true,
+  key_ops: ["verify"],
+});
+
+// From https://www.rfc-editor.org/rfc/rfc7517#appendix-A.2
+const createPrivateEcdsaJsonWebKeyData = () => ({
+  kty: "EC",
+  crv: "P-256",
+  x: "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+  y: "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+  d: "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE",
+  use: "sig",
+  kid: "1",
+  ext: true,
+  key_ops: ["sign"],
+});
+
+// From https://www.rfc-editor.org/rfc/rfc7517#appendix-A.2
+const createPrivateRsaJsonWebKeyData = () => ({
+  alg: "RS256",
+  d: "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q",
+  dp: "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0",
+  dq: "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk",
+  e: "AQAB",
+  ext: true,
+  key_ops: ["sign"],
+  kty: "RSA",
+  n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+  p: "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs",
+  q: "3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk",
+  qi: "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
+});
+
+const createRsaJsonWebKeyAlgorithm = () => ({
+  name: "RSASSA-PKCS1-v1_5",
+  hash: { name: "SHA-256" },
+});
+
+const ecdsaJsonWebKeyAlgorithm = Object.freeze({
+  name: "ECDSA",
+  namedCurve: "P-256",
+  hash: Object.freeze({ name: "SHA-256" }),
+});
+
+export const handler = serveTest(async (t) => {
+  t.test("crypto", () => {
+    strictEqual(typeof crypto, "object", `typeof crypto`);
+    strictEqual(crypto instanceof Crypto, true, `crypto instanceof Crypto`);
+  });
+
+  await t.test("subtle", async () => {
+    strictEqual(typeof crypto.subtle, "object", `typeof crypto.subtle`);
+    strictEqual(
+      crypto.subtle instanceof SubtleCrypto,
+      true,
+      `crypto.subtle instanceof SubtleCrypto`
+    );
+  });
+
+  // importKey
+  {
+    await t.test("subtle.importKey", async () => {
+      strictEqual(
+        typeof crypto.subtle.importKey,
+        "function",
+        `typeof crypto.subtle.importKey`
+      );
+      strictEqual(
+        crypto.subtle.importKey,
+        SubtleCrypto.prototype.importKey,
+        `crypto.subtle.importKey === SubtleCrypto.prototype.importKey`
+      );
+    });
+    await t.test("subtle.importKey.length", async () => {
+      strictEqual(
+        crypto.subtle.importKey.length,
+        5,
+        `crypto.subtle.importKey.length === 5`
+      );
+    });
+    await t.test("subtle.importKey.called-as-constructor", async () => {
+      throws(
+        () => {
+          new crypto.subtle.importKey();
+        },
+        TypeError,
+        "crypto.subtle.importKey is not a constructor"
+      );
+    });
+    await t.test("subtle.importKey.called-with-wrong-this", async () => {
+      const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+      await rejects(
+        async () => {
+          await crypto.subtle.importKey.call(
+            undefined,
+            "jwk",
+            publicRsaJsonWebKeyData,
+            createRsaJsonWebKeyAlgorithm(),
+            publicRsaJsonWebKeyData.ext,
+            publicRsaJsonWebKeyData.key_ops
+          );
+        },
+        TypeError,
+        "Method SubtleCrypto.importKey called on receiver that's not an instance of SubtleCrypto"
+      );
+    });
+    await t.test("subtle.importKey.called-with-no-arguments", async () => {
+      await rejects(
+        async () => {
+          await crypto.subtle.importKey();
+        },
+        TypeError,
+        "SubtleCrypto.importKey: At least 5 arguments required, but only 0 passed"
+      );
+    });
+
+    // first-parameter
+    {
+      await t.test(
+        "subtle.importKey.first-parameter-calls-7.1.17-ToString",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const sentinel = Symbol("sentinel");
+          const test = async () => {
+            const format = {
+              toString() {
+                throw sentinel;
+              },
+            };
+            await crypto.subtle.importKey(
+              format,
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+      await t.test(
+        "subtle.importKey.first-parameter-non-existant-format",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              await crypto.subtle.importKey(
+                "jake",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+            },
+            Error,
+            "Provided format parameter is not supported. Supported formats are: 'spki', 'pkcs8', 'jwk', and 'raw'"
+          );
+        }
+      );
+    }
+
+    // second-parameter
+    {
+      await t.test(
+        "subtle.importKey.second-parameter-invalid-format",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              await crypto.subtle.importKey(
+                "jwk",
+                Symbol(),
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+            },
+            Error,
+            "The provided value is not of type JsonWebKey"
+          );
+        }
+      );
+      // jwk public key
+      {
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-missing-e-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                delete publicRsaJsonWebKeyData.e;
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  publicRsaJsonWebKeyData.key_ops
+                );
+              },
+              DOMException,
+              "Data provided to an operation does not meet requirements"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-e-field-calls-7.1.17-ToString",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const test = async () => {
+              sentinel = Symbol();
+              publicRsaJsonWebKeyData.e = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-invalid-e-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                publicRsaJsonWebKeyData.e = "`~!@#@#$Q%^%&^*";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  publicRsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK member 'e' could not be base64url decoded or contained padding"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-missing-kty-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                delete publicRsaJsonWebKeyData.kty;
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  publicRsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The required JWK member 'kty' was missing"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-invalid-kty-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                publicRsaJsonWebKeyData.kty = "jake";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  publicRsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK 'kty' member was not 'RSA'"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-missing-key_ops-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            const key_ops = Array.from(publicRsaJsonWebKeyData.key_ops);
+            delete publicRsaJsonWebKeyData.key_ops;
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              key_ops
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-non-sequence-key_ops-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                const key_ops = Array.from(publicRsaJsonWebKeyData.key_ops);
+                publicRsaJsonWebKeyData.key_ops = "jake";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  key_ops
+                );
+              },
+              Error,
+              "Failed to read the 'key_ops' property from 'JsonWebKey': The provided value cannot be converted to a sequence"
+            );
+          }
+        );
+
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-empty-key_ops-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            const key_ops = Array.from(publicRsaJsonWebKeyData.key_ops);
+            publicRsaJsonWebKeyData.key_ops = [];
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              key_ops
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-duplicated-key_ops-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                const key_ops = Array.from(publicRsaJsonWebKeyData.key_ops);
+                publicRsaJsonWebKeyData.key_ops = ["sign", "sign"];
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  key_ops
+                );
+              },
+              Error,
+              "The 'key_ops' member of the JWK dictionary contains duplicate usages"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-invalid-key_ops-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                const key_ops = Array.from(publicRsaJsonWebKeyData.key_ops);
+                publicRsaJsonWebKeyData.key_ops = ["sign", "jake"];
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  key_ops
+                );
+              },
+              TypeError,
+              "Invalid keyUsages argument"
+            );
+          }
+        );
+
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-key_ops-field-calls-7.1.17-ToString",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const key_ops = Array.from(publicRsaJsonWebKeyData.key_ops);
+            const test = async () => {
+              sentinel = Symbol();
+              const op = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              publicRsaJsonWebKeyData.key_ops = ["sign", op];
+              await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-missing-n-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                delete publicRsaJsonWebKeyData.n;
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  publicRsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "Data provided to an operation does not meet requirements"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-n-field-calls-7.1.17-ToString",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const test = async () => {
+              sentinel = Symbol();
+              publicRsaJsonWebKeyData.n = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+        await t.test(
+          "subtle.importKey.rsa-jwk-public.second-parameter-invalid-n-field",
+          async () => {
+            const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                publicRsaJsonWebKeyData.n = "`~!@#@#$Q%^%&^*";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicRsaJsonWebKeyData,
+                  createRsaJsonWebKeyAlgorithm(),
+                  publicRsaJsonWebKeyData.ext,
+                  publicRsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK member 'n' could not be base64url decoded or contained padding"
+            );
+          }
+        );
+      }
+      // jwk private key
+      // TODO
+      // raw HMAC secret keys
+      // TODO
+      // raw Elliptic Curve public keys
+      {
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-missing-x-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                delete publicEcdsaJsonWebKeyData.x;
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  publicEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              DOMException,
+              "Data provided to an operation does not meet requirements"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-x-field-calls-7.1.17-ToString",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const test = async () => {
+              sentinel = Symbol();
+              publicEcdsaJsonWebKeyData.x = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              await crypto.subtle.importKey(
+                "jwk",
+                publicEcdsaJsonWebKeyData,
+                ecdsaJsonWebKeyAlgorithm,
+                publicEcdsaJsonWebKeyData.ext,
+                publicEcdsaJsonWebKeyData.key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-invalid-x-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                publicEcdsaJsonWebKeyData.x = "`~!@#@#$Q%^%&^*";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  publicEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK member 'x' could not be base64url decoded or contained padding"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-missing-y-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                delete publicEcdsaJsonWebKeyData.y;
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  publicEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              DOMException,
+              "Data provided to an operation does not meet requirements"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-y-field-calls-7.1.17-ToString",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const test = async () => {
+              sentinel = Symbol();
+              publicEcdsaJsonWebKeyData.y = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              await crypto.subtle.importKey(
+                "jwk",
+                publicEcdsaJsonWebKeyData,
+                ecdsaJsonWebKeyAlgorithm,
+                publicEcdsaJsonWebKeyData.ext,
+                publicEcdsaJsonWebKeyData.key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-invalid-y-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                publicEcdsaJsonWebKeyData.y = "`~!@#@#$Q%^%&^*";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  publicEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK member 'y' could not be base64url decoded or contained padding"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-missing-kty-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                delete publicEcdsaJsonWebKeyData.kty;
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  publicEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The required JWK member 'kty' was missing"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-invalid-kty-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                publicEcdsaJsonWebKeyData.kty = "jake";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  publicEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK 'kty' member was not 'EC'"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-missing-key_ops-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            const key_ops = Array.from(publicEcdsaJsonWebKeyData.key_ops);
+            delete publicEcdsaJsonWebKeyData.key_ops;
+            await crypto.subtle.importKey(
+              "jwk",
+              publicEcdsaJsonWebKeyData,
+              ecdsaJsonWebKeyAlgorithm,
+              publicEcdsaJsonWebKeyData.ext,
+              key_ops
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-non-sequence-key_ops-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                const key_ops = Array.from(publicEcdsaJsonWebKeyData.key_ops);
+                publicEcdsaJsonWebKeyData.key_ops = "jake";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  key_ops
+                );
+              },
+              Error,
+              "Failed to read the 'key_ops' property from 'JsonWebKey': The provided value cannot be converted to a sequence"
+            );
+          }
+        );
+
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-empty-key_ops-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            const key_ops = Array.from(publicEcdsaJsonWebKeyData.key_ops);
+            publicEcdsaJsonWebKeyData.key_ops = [];
+            await crypto.subtle.importKey(
+              "jwk",
+              publicEcdsaJsonWebKeyData,
+              ecdsaJsonWebKeyAlgorithm,
+              publicEcdsaJsonWebKeyData.ext,
+              key_ops
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-duplicated-key_ops-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                const key_ops = Array.from(publicEcdsaJsonWebKeyData.key_ops);
+                publicEcdsaJsonWebKeyData.key_ops = ["sign", "sign"];
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  key_ops
+                );
+              },
+              Error,
+              "The 'key_ops' member of the JWK dictionary contains duplicate usages"
+            );
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-invalid-key_ops-field",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                const key_ops = Array.from(publicEcdsaJsonWebKeyData.key_ops);
+                publicEcdsaJsonWebKeyData.key_ops = ["sign", "jake"];
+                await crypto.subtle.importKey(
+                  "jwk",
+                  publicEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  publicEcdsaJsonWebKeyData.ext,
+                  key_ops
+                );
+              },
+              TypeError,
+              "Invalid keyUsages argument"
+            );
+          }
+        );
+
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-public.second-parameter-key_ops-field-calls-7.1.17-ToString",
+          async () => {
+            const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const key_ops = Array.from(publicEcdsaJsonWebKeyData.key_ops);
+            const test = async () => {
+              sentinel = Symbol();
+              const op = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              publicEcdsaJsonWebKeyData.key_ops = ["sign", op];
+              await crypto.subtle.importKey(
+                "jwk",
+                publicEcdsaJsonWebKeyData,
+                ecdsaJsonWebKeyAlgorithm,
+                publicEcdsaJsonWebKeyData.ext,
+                key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-private.second-parameter-d-field-calls-7.1.17-ToString",
+          async () => {
+            const privateEcdsaJsonWebKeyData =
+              createPrivateEcdsaJsonWebKeyData();
+            let sentinel = Symbol("sentinel");
+            const test = async () => {
+              sentinel = Symbol();
+              privateEcdsaJsonWebKeyData.d = {
+                toString() {
+                  throw sentinel;
+                },
+              };
+              await crypto.subtle.importKey(
+                "jwk",
+                privateEcdsaJsonWebKeyData,
+                ecdsaJsonWebKeyAlgorithm,
+                privateEcdsaJsonWebKeyData.ext,
+                privateEcdsaJsonWebKeyData.key_ops
+              );
+            };
+            await rejects(test);
+            try {
+              await test();
+            } catch (thrownError) {
+              strictEqual(thrownError, sentinel, "thrownError === sentinel");
+            }
+          }
+        );
+        await t.test(
+          "subtle.importKey.ecdsa-jwk-private.second-parameter-invalid-d-field",
+          async () => {
+            const privateEcdsaJsonWebKeyData =
+              createPrivateEcdsaJsonWebKeyData();
+            await rejects(
+              async () => {
+                privateEcdsaJsonWebKeyData.d = "`~!@#@#$Q%^%&^*";
+                await crypto.subtle.importKey(
+                  "jwk",
+                  privateEcdsaJsonWebKeyData,
+                  ecdsaJsonWebKeyAlgorithm,
+                  privateEcdsaJsonWebKeyData.ext,
+                  privateEcdsaJsonWebKeyData.key_ops
+                );
+              },
+              Error,
+              "The JWK member 'd' could not be base64url decoded or contained padding"
+            );
+          }
+        );
+      }
+      // pkcs8 Elliptic Curve private keys
+      // TODO
+      // pkcs8 RSA private keys
+      // raw AES
+    }
+    // third-parameter
+    {
+      await t.test("subtle.importKey.third-parameter-undefined", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        await rejects(
+          async () => {
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              undefined,
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+          },
+          Error,
+          "Algorithm: Unrecognized name"
+        );
+      });
+      await t.test(
+        "subtle.importKey.third-parameter-name-field-calls-7.1.17-ToString",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const rsaJsonWebKeyAlgorithm = createRsaJsonWebKeyAlgorithm();
+          const sentinel = Symbol("sentinel");
+          const test = async () => {
+            rsaJsonWebKeyAlgorithm.name = {
+              toString() {
+                throw sentinel;
+              },
+            };
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              rsaJsonWebKeyAlgorithm,
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+      await t.test(
+        "subtle.importKey.third-parameter-invalid-name-field",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const rsaJsonWebKeyAlgorithm = createRsaJsonWebKeyAlgorithm();
+          await rejects(
+            async () => {
+              rsaJsonWebKeyAlgorithm.name = "`~!@#@#$Q%^%&^*";
+              await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                rsaJsonWebKeyAlgorithm,
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+            },
+            Error,
+            "Algorithm: Unrecognized name"
+          );
+        }
+      );
+      await t.test(
+        "subtle.importKey.third-parameter-hash-name-field-calls-7.1.17-ToString",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const rsaJsonWebKeyAlgorithm = createRsaJsonWebKeyAlgorithm();
+          const sentinel = Symbol("sentinel");
+          const test = async () => {
+            rsaJsonWebKeyAlgorithm.hash.name = {
+              toString() {
+                throw sentinel;
+              },
+            };
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              rsaJsonWebKeyAlgorithm,
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+      await t.test(
+        "subtle.importKey.third-parameter-hash-algorithm-does-not-match-json-web-key-hash-algorithm",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const rsaJsonWebKeyAlgorithm = createRsaJsonWebKeyAlgorithm();
+          await rejects(
+            async () => {
+              rsaJsonWebKeyAlgorithm.hash.name = "SHA-1";
+              await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                rsaJsonWebKeyAlgorithm,
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+            },
+            Error,
+            "The JWK 'alg' member was inconsistent with that specified by the Web Crypto call"
+          );
+        }
+      );
+    }
+
+    // fifth-parameter
+    {
+      await t.test("subtle.importKey.fifth-parameter-undefined", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        await rejects(
+          async () => {
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              undefined
+            );
+          },
+          Error,
+          "The provided value cannot be converted to a sequence"
+        );
+      });
+      await t.test("subtle.importKey.fifth-parameter-invalid", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        await rejects(
+          async () => {
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              ["jake"]
+            );
+          },
+          Error,
+          "SubtleCrypto.importKey: Invalid keyUsages argument"
+        );
+      });
+      await t.test(
+        "subtle.importKey.fifth-parameter-duplicate-operations",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const key_ops = publicRsaJsonWebKeyData.key_ops.concat(
+            publicRsaJsonWebKeyData.key_ops
+          );
+          await crypto.subtle.importKey(
+            "jwk",
+            publicRsaJsonWebKeyData,
+            createRsaJsonWebKeyAlgorithm(),
+            publicRsaJsonWebKeyData.ext,
+            key_ops
+          );
+        }
+      );
+
+      await t.test(
+        "subtle.importKey.fifth-parameter-operations-do-not-match-json-web-key-operations",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                ["sign"]
+              );
+            },
+            Error,
+            "The JWK 'key_ops' member was inconsistent with that specified by the Web Crypto call. The JWK usage must be a superset of those requested"
+          );
+        }
+      );
+
+      await t.test(
+        "subtle.importKey.fifth-parameter-operation-fields-calls-7.1.17-ToString",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          let sentinel = Symbol("sentinel");
+          const test = async () => {
+            sentinel = Symbol();
+            const op = {
+              toString() {
+                throw sentinel;
+              },
+            };
+            await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              ["sign", op]
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+    }
+
+    // happy paths
+    {
+      await t.test("subtle.importKey.JWK-RS256-Public", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          publicRsaJsonWebKeyData,
+          createRsaJsonWebKeyAlgorithm(),
+          publicRsaJsonWebKeyData.ext,
+          publicRsaJsonWebKeyData.key_ops
+        );
+        strictEqual(key instanceof CryptoKey, true, `key instanceof CryptoKey`);
+        deepStrictEqual(
+          key.algorithm,
+          {
+            name: "RSASSA-PKCS1-v1_5",
+            hash: {
+              name: "SHA-256",
+            },
+            modulusLength: 2048,
+            publicExponent: new Uint8Array([1, 0, 1]),
+          },
+          `key.algorithm`
+        );
+        strictEqual(key.extractable, true, `key.extractable === true`);
+        strictEqual(key.type, "public", `key.type === "public"`);
+        deepStrictEqual(
+          key.usages,
+          ["verify"],
+          `key.usages deep equals ["verify"]`
+        );
+      });
+
+      await t.test("subtle.importKey.JWK-EC256-Public", async () => {
+        const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          publicEcdsaJsonWebKeyData,
+          ecdsaJsonWebKeyAlgorithm,
+          publicEcdsaJsonWebKeyData.ext,
+          publicEcdsaJsonWebKeyData.key_ops
+        );
+        strictEqual(key instanceof CryptoKey, true, `key instanceof CryptoKey`);
+        deepStrictEqual(
+          key.algorithm,
+          {
+            name: "ECDSA",
+            namedCurve: "P-256",
+          },
+          `key.algorithm`
+        );
+        strictEqual(key.extractable, true, `key.extractable === true`);
+        strictEqual(key.type, "public", `key.type === "public"`);
+        deepStrictEqual(
+          key.usages,
+          ["verify"],
+          `key.usages deep equals ["verify"]`
+        );
+      });
+
+      await t.test("subtle.importKey.HMAC", async () => {
+        const keyUint8Array = new Uint8Array([1, 0, 1]);
+
+        for (const algorithm of ["SHA-1", "SHA-256", "SHA-384", "SHA-512"]) {
+          const key = await globalThis.crypto.subtle.importKey(
+            "raw",
+            keyUint8Array,
+            { name: "HMAC", hash: algorithm },
+            false,
+            ["sign", "verify"]
+          );
+          strictEqual(
+            key instanceof CryptoKey,
+            true,
+            `key instanceof CryptoKey`
+          );
+          deepStrictEqual(
+            key.algorithm,
+            {
+              name: "HMAC",
+              hash: { name: algorithm },
+              length: 24,
+            },
+            `key.algorithm`
+          );
+          strictEqual(key.extractable, false, `key.extractable`);
+          strictEqual(key.type, "secret", `key.type`);
+          deepStrictEqual(key.usages, ["sign", "verify"], `key.usages`);
+        }
+      });
+      await t.test("subtle.importKey.JWK-HS256-Public", async () => {
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          {
+            kty: "oct",
+            k: "Y0zt37HgOx-BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE",
+            alg: "HS256",
+            ext: true,
+          },
+          {
+            name: "HMAC",
+            hash: { name: "SHA-256" },
+          },
+          false,
+          ["sign", "verify"]
+        );
+        strictEqual(key instanceof CryptoKey, true, `key instanceof CryptoKey`);
+        deepStrictEqual(
+          key.algorithm,
+          {
+            name: "HMAC",
+            hash: { name: "SHA-256" },
+            length: 256,
+          },
+          `key.algorithm`
+        );
+        strictEqual(key.extractable, false, `key.extractable`);
+        strictEqual(key.type, "secret", `key.type`);
+        deepStrictEqual(key.usages, ["sign", "verify"], `key.usages`);
+      });
+    }
+  }
+
+  // digest
+  {
+    const enc = new TextEncoder();
+    const data = enc.encode("hello world");
+    await t.test("subtle.digest", async () => {
+      strictEqual(
+        typeof crypto.subtle.digest,
+        "function",
+        `typeof crypto.subtle.digest`
+      );
+      strictEqual(
+        crypto.subtle.digest,
+        SubtleCrypto.prototype.digest,
+        `crypto.subtle.digest === SubtleCrypto.prototype.digest`
+      );
+    });
+    await t.test("subtle.digest.length", async () => {
+      strictEqual(
+        crypto.subtle.digest.length,
+        2,
+        `crypto.subtle.digest.length === 2`
+      );
+    });
+    await t.test("subtle.digest.called-as-constructor", async () => {
+      throws(
+        () => {
+          new crypto.subtle.digest();
+        },
+        TypeError,
+        "crypto.subtle.digest is not a constructor"
+      );
+    });
+    await t.test("subtle.digest.called-with-wrong-this", async () => {
+      await rejects(
+        async () => {
+          await crypto.subtle.digest.call(undefined);
+        },
+        TypeError,
+        "Method SubtleCrypto.digest called on receiver that's not an instance of SubtleCrypto"
+      );
+    });
+    await t.test("subtle.digest.called-with-no-arguments", async () => {
+      await rejects(
+        async () => {
+          await crypto.subtle.digest();
+        },
+        TypeError,
+        "SubtleCrypto.digest: At least 2 arguments required, but only 0 passed"
+      );
+    });
+
+    // first-parameter
+    {
+      await t.test(
+        "subtle.digest.first-parameter-calls-7.1.17-ToString",
+        async () => {
+          const sentinel = Symbol("sentinel");
+          const test = async () => {
+            await crypto.subtle.digest(
+              {
+                name: {
+                  toString() {
+                    throw sentinel;
+                  },
+                },
+              },
+              data
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+      await t.test(
+        "subtle.digest.first-parameter-non-existant-format",
+        async () => {
+          await rejects(
+            async () => {
+              await crypto.subtle.digest("jake", data);
+            },
+            Error,
+            "Algorithm: Unrecognized name"
+          );
+        }
+      );
+    }
+    // second-parameter
+    {
+      await t.test("subtle.digest.second-parameter-undefined", async () => {
+        await rejects(
+          async () => {
+            await crypto.subtle.digest("sha-1", undefined);
+          },
+          Error,
+          'SubtleCrypto.digest: data must be of type ArrayBuffer or ArrayBufferView but got ""'
+        );
+      });
+    }
+    // happy paths
+    {
+      // "MD5"
+      await t.test("subtle.digest.md5", async () => {
+        const result = new Uint8Array(
+          await crypto.subtle.digest("md5", new Uint8Array())
+        );
+        const expected = new Uint8Array([
+          212, 29, 140, 217, 143, 0, 178, 4, 233, 128, 9, 152, 236, 248, 66,
+          126,
+        ]);
+        deepStrictEqual(result, expected, "result deep equals expected");
+      });
+      // "SHA-1"
+      await t.test("subtle.digest.sha-1", async () => {
+        const result = new Uint8Array(
+          await crypto.subtle.digest("sha-1", new Uint8Array())
+        );
+        const expected = new Uint8Array([
+          218, 57, 163, 238, 94, 107, 75, 13, 50, 85, 191, 239, 149, 96, 24,
+          144, 175, 216, 7, 9,
+        ]);
+        deepStrictEqual(result, expected, "result deep equals expected");
+      });
+      // "SHA-256"
+      await t.test("subtle.digest.sha-256", async () => {
+        const result = new Uint8Array(
+          await crypto.subtle.digest("sha-256", new Uint8Array())
+        );
+        const expected = new Uint8Array([
+          227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111,
+          185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120,
+          82, 184, 85,
+        ]);
+        deepStrictEqual(result, expected, "result deep equals expected");
+      });
+      // "SHA-384"
+      await t.test("subtle.digest.sha-384", async () => {
+        const result = new Uint8Array(
+          await crypto.subtle.digest("sha-384", new Uint8Array())
+        );
+        const expected = new Uint8Array([
+          56, 176, 96, 167, 81, 172, 150, 56, 76, 217, 50, 126, 177, 177, 227,
+          106, 33, 253, 183, 17, 20, 190, 7, 67, 76, 12, 199, 191, 99, 246, 225,
+          218, 39, 78, 222, 191, 231, 111, 101, 251, 213, 26, 210, 241, 72, 152,
+          185, 91,
+        ]);
+        deepStrictEqual(result, expected, "result deep equals expected");
+      });
+      // "SHA-512"
+      await t.test("subtle.digest.sha-512", async () => {
+        const result = new Uint8Array(
+          await crypto.subtle.digest("sha-512", new Uint8Array())
+        );
+        const expected = new Uint8Array([
+          207, 131, 225, 53, 126, 239, 184, 189, 241, 84, 40, 80, 214, 109, 128,
+          7, 214, 32, 228, 5, 11, 87, 21, 220, 131, 244, 169, 33, 211, 108, 233,
+          206, 71, 208, 209, 60, 93, 133, 242, 176, 255, 131, 24, 210, 135, 126,
+          236, 47, 99, 185, 49, 189, 71, 65, 122, 129, 165, 56, 50, 122, 249,
+          39, 218, 62,
+        ]);
+        deepStrictEqual(result, expected, "result deep equals expected");
+      });
+    }
+  }
+
+  // sign
+  {
+    const enc = new TextEncoder();
+    const data = enc.encode("hello world");
+    await t.test("subtle.sign", async () => {
+      strictEqual(
+        typeof crypto.subtle.sign,
+        "function",
+        `typeof crypto.subtle.sign`
+      );
+      strictEqual(
+        crypto.subtle.sign,
+        SubtleCrypto.prototype.sign,
+        `crypto.subtle.sign === SubtleCrypto.prototype.sign`
+      );
+    });
+    await t.test("subtle.sign.length", async () => {
+      strictEqual(
+        crypto.subtle.sign.length,
+        3,
+        `crypto.subtle.sign.length === 3`
+      );
+    });
+    await t.test("subtle.sign.called-as-constructor", async () => {
+      throws(
+        () => {
+          new crypto.subtle.sign();
+        },
+        TypeError,
+        "crypto.subtle.sign is not a constructor"
+      );
+    });
+    await t.test("subtle.sign.called-with-wrong-this", async () => {
+      const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+      await rejects(
+        async () => {
+          await crypto.subtle.sign.call(
+            undefined,
+            createRsaJsonWebKeyAlgorithm(),
+            publicRsaJsonWebKeyData,
+            data
+          );
+        },
+        TypeError,
+        "Method SubtleCrypto.sign called on receiver that's not an instance of SubtleCrypto"
+      );
+    });
+    await t.test("subtle.sign.called-with-no-arguments", async () => {
+      await rejects(
+        async () => {
+          await crypto.subtle.sign();
+        },
+        TypeError,
+        "SubtleCrypto.sign: At least 3 arguments required, but only 0 passed"
+      );
+    });
+    // first-parameter
+    {
+      await t.test(
+        "subtle.sign.first-parameter-calls-7.1.17-ToString",
+        async () => {
+          const privateRsaJsonWebKeyData = createPrivateRsaJsonWebKeyData();
+          const sentinel = Symbol("sentinel");
+          const key = await crypto.subtle.importKey(
+            "jwk",
+            privateRsaJsonWebKeyData,
+            createRsaJsonWebKeyAlgorithm(),
+            privateRsaJsonWebKeyData.ext,
+            privateRsaJsonWebKeyData.key_ops
+          );
+          const test = async () => {
+            await crypto.subtle.sign(
+              {
+                name: {
+                  toString() {
+                    throw sentinel;
+                  },
+                },
+              },
+              key,
+              data
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+      await t.test(
+        "subtle.sign.first-parameter-non-existant-algorithm",
+        async () => {
+          const privateRsaJsonWebKeyData = createPrivateRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              const key = await crypto.subtle.importKey(
+                "jwk",
+                privateRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                privateRsaJsonWebKeyData.ext,
+                privateRsaJsonWebKeyData.key_ops
+              );
+              await crypto.subtle.sign("jake", key, data);
+            },
+            Error,
+            "Algorithm: Unrecognized name"
+          );
+        }
+      );
+    }
+    // second-parameter
+    {
+      await t.test("subtle.sign.second-parameter-invalid-format", async () => {
+        await rejects(
+          async () => {
+            await crypto.subtle.sign(
+              createRsaJsonWebKeyAlgorithm(),
+              "jake",
+              data
+            );
+          },
+          Error,
+          "parameter 2 is not of type 'CryptoKey'"
+        );
+      });
+      await t.test("subtle.sign.second-parameter-invalid-usages", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        await rejects(
+          async () => {
+            const key = await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+            await crypto.subtle.sign(createRsaJsonWebKeyAlgorithm(), key, data);
+          },
+          Error,
+          "CryptoKey doesn't support signing"
+        );
+      });
+    }
+    // third-parameter
+    {
+      await t.test("subtle.sign.third-parameter-invalid-format", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        await rejects(
+          async () => {
+            const key = await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+            await crypto.subtle.sign(
+              createRsaJsonWebKeyAlgorithm(),
+              key,
+              undefined
+            );
+          },
+          Error,
+          'SubtleCrypto.sign: data must be of type ArrayBuffer or ArrayBufferView but got ""'
+        );
+      });
+    }
+    // happy-path
+    {
+      await t.test("subtle.sign.happy-path-jwk", async () => {
+        const privateRsaJsonWebKeyData = createPrivateRsaJsonWebKeyData();
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          privateRsaJsonWebKeyData,
+          createRsaJsonWebKeyAlgorithm(),
+          privateRsaJsonWebKeyData.ext,
+          privateRsaJsonWebKeyData.key_ops
+        );
+        const signature = new Uint8Array(
+          await crypto.subtle.sign(createRsaJsonWebKeyAlgorithm(), key, data)
+        );
+        const expected = new Uint8Array([
+          70, 96, 33, 185, 93, 42, 67, 49, 243, 70, 88, 68, 194, 148, 53, 249,
+          255, 192, 232, 132, 161, 194, 41, 244, 174, 211, 218, 203, 7, 238, 71,
+          182, 101, 49, 139, 222, 165, 70, 222, 105, 82, 156, 184, 44, 100, 108,
+          121, 237, 250, 119, 66, 228, 156, 243, 71, 105, 62, 246, 22, 2, 160,
+          116, 71, 147, 202, 168, 24, 92, 224, 41, 148, 161, 124, 80, 212, 169,
+          212, 64, 29, 189, 2, 171, 174, 188, 159, 89, 93, 122, 219, 166, 105,
+          92, 107, 173, 103, 238, 145, 226, 94, 139, 71, 124, 17, 233, 49, 138,
+          89, 246, 3, 82, 238, 154, 169, 188, 66, 198, 32, 23, 230, 90, 164,
+          140, 51, 47, 221, 149, 161, 14, 254, 169, 224, 223, 119, 94, 27, 63,
+          199, 93, 65, 53, 24, 151, 146, 242, 239, 41, 108, 136, 31, 99, 42,
+          213, 128, 244, 140, 238, 157, 107, 117, 241, 219, 137, 97, 39, 109,
+          185, 176, 97, 193, 60, 117, 244, 106, 62, 193, 188, 87, 199, 37, 70,
+          137, 37, 231, 110, 228, 228, 139, 53, 240, 56, 92, 102, 220, 176, 127,
+          248, 24, 217, 208, 29, 209, 216, 29, 251, 100, 252, 243, 183, 195, 96,
+          126, 102, 136, 48, 39, 186, 45, 202, 10, 187, 22, 52, 183, 190, 149,
+          153, 32, 12, 90, 66, 49, 122, 190, 154, 167, 9, 12, 32, 77, 177, 222,
+          54, 211, 233, 219, 205, 133, 0, 113, 77, 158, 1, 125, 5, 15, 195,
+        ]);
+        deepStrictEqual(signature, expected, "signature deep equals expected");
+      });
+      await t.test("subtle.sign.happy-path-hmac", async () => {
+        const encoder = new TextEncoder();
+        const messageUint8Array = encoder.encode("aki");
+        const keyUint8Array = new Uint8Array([1, 0, 1]);
+        const results = {
+          "SHA-1": new Uint8Array([
+            222, 61, 81, 133, 232, 89, 130, 225, 248, 25, 220, 34, 245, 103, 89,
+            127, 136, 77, 146, 166,
+          ]),
+          "SHA-256": new Uint8Array([
+            92, 237, 16, 210, 91, 89, 194, 36, 95, 98, 27, 175, 64, 25, 15, 160,
+            152, 178, 145, 235, 62, 92, 23, 202, 125, 228, 8, 25, 148, 26, 215,
+            242,
+          ]),
+          "SHA-384": new Uint8Array([
+            238, 20, 74, 173, 238, 236, 161, 229, 250, 167, 72, 210, 188, 239,
+            233, 39, 233, 166, 114, 241, 140, 229, 201, 129, 243, 173, 74, 198,
+            223, 145, 228, 96, 253, 91, 166, 111, 244, 23, 141, 62, 112, 156,
+            90, 166, 214, 69, 185, 48,
+          ]),
+          "SHA-512": new Uint8Array([
+            211, 127, 139, 149, 23, 225, 84, 230, 82, 249, 109, 254, 168, 236,
+            217, 112, 174, 52, 231, 62, 167, 197, 33, 11, 181, 21, 162, 236,
+            214, 132, 43, 161, 92, 112, 230, 182, 140, 69, 169, 229, 87, 98, 57,
+            81, 140, 134, 219, 253, 139, 169, 85, 181, 195, 195, 166, 241, 219,
+            33, 9, 56, 67, 213, 51, 224,
+          ]),
+        };
+
+        for (const algorithm of ["SHA-1", "SHA-256", "SHA-384", "SHA-512"]) {
+          const key = await globalThis.crypto.subtle.importKey(
+            "raw",
+            keyUint8Array,
+            { name: "HMAC", hash: algorithm },
+            false,
+            ["sign", "verify"]
+          );
+          // Sign the message with HMAC and the CryptoKey
+          const signature = new Uint8Array(
+            await globalThis.crypto.subtle.sign("HMAC", key, messageUint8Array)
+          );
+          const expected = results[algorithm];
+          deepStrictEqual(
+            signature,
+            expected,
+            `${algorithm} signature deep equals expected`
+          );
+        }
+      });
+    }
+  }
+
+  // verify
+  {
+    await t.test("subtle.verify", async () => {
+      strictEqual(
+        typeof crypto.subtle.verify,
+        "function",
+        `typeof crypto.subtle.verify`
+      );
+      strictEqual(
+        crypto.subtle.verify,
+        SubtleCrypto.prototype.verify,
+        `crypto.subtle.verify === SubtleCrypto.prototype.verify`
+      );
+    });
+    await t.test("subtle.verify.length", async () => {
+      strictEqual(
+        crypto.subtle.verify.length,
+        4,
+        `crypto.subtle.verify.length === 4`
+      );
+    });
+    await t.test("subtle.verify.called-as-constructor", async () => {
+      throws(
+        () => {
+          new crypto.subtle.verify();
+        },
+        TypeError,
+        "crypto.subtle.verify is not a constructor"
+      );
+    });
+    await t.test("subtle.verify.called-with-wrong-this", async () => {
+      const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+      await rejects(
+        async () => {
+          const key = await crypto.subtle.importKey(
+            "jwk",
+            publicRsaJsonWebKeyData,
+            createRsaJsonWebKeyAlgorithm(),
+            publicRsaJsonWebKeyData.ext,
+            publicRsaJsonWebKeyData.key_ops
+          );
+          await crypto.subtle.verify.call(
+            undefined,
+            createRsaJsonWebKeyAlgorithm(),
+            key,
+            new Uint8Array(),
+            new Uint8Array()
+          );
+        },
+        TypeError,
+        "Method SubtleCrypto.verify called on receiver that's not an instance of SubtleCrypto"
+      );
+    });
+    await t.test("subtle.verify.called-with-no-arguments", async () => {
+      await rejects(
+        async () => {
+          await crypto.subtle.verify();
+        },
+        TypeError,
+        "SubtleCrypto.verify: At least 4 arguments required, but only 0 passed"
+      );
+    });
+    // first-parameter
+    {
+      await t.test(
+        "subtle.verify.first-parameter-calls-7.1.17-ToString",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          const sentinel = Symbol("sentinel");
+          const test = async () => {
+            const key = await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+            await crypto.subtle.verify(
+              {
+                name: {
+                  toString() {
+                    throw sentinel;
+                  },
+                },
+              },
+              key,
+              new Uint8Array(),
+              new Uint8Array()
+            );
+          };
+          await rejects(test);
+          try {
+            await test();
+          } catch (thrownError) {
+            strictEqual(thrownError, sentinel, "thrownError === sentinel");
+          }
+        }
+      );
+      await t.test(
+        "subtle.verify.first-parameter-non-existant-algorithm",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              const key = await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+              await crypto.subtle.verify(
+                "jake",
+                key,
+                new Uint8Array(),
+                new Uint8Array()
+              );
+            },
+            Error,
+            "Algorithm: Unrecognized name"
+          );
+        }
+      );
+    }
+    // second-parameter
+    {
+      await t.test(
+        "subtle.verify.second-parameter-invalid-format",
+        async () => {
+          await rejects(
+            async () => {
+              await crypto.subtle.verify(
+                createRsaJsonWebKeyAlgorithm(),
+                "jake",
+                new Uint8Array(),
+                new Uint8Array()
+              );
+            },
+            Error,
+            "parameter 2 is not of type 'CryptoKey'"
+          );
+        }
+      );
+      await t.test(
+        "subtle.verify.second-parameter-invalid-usages",
+        async () => {
+          const privateRsaJsonWebKeyData = createPrivateRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              const key = await crypto.subtle.importKey(
+                "jwk",
+                privateRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                privateRsaJsonWebKeyData.ext,
+                privateRsaJsonWebKeyData.key_ops
+              );
+              await crypto.subtle.verify(
+                createRsaJsonWebKeyAlgorithm(),
+                key,
+                new Uint8Array(),
+                new Uint8Array()
+              );
+            },
+            Error,
+            "CryptoKey doesn't support verification"
+          );
+        }
+      );
+    }
+    // third-parameter
+    {
+      await t.test("subtle.verify.third-parameter-invalid-format", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        await rejects(
+          async () => {
+            const key = await crypto.subtle.importKey(
+              "jwk",
+              publicRsaJsonWebKeyData,
+              createRsaJsonWebKeyAlgorithm(),
+              publicRsaJsonWebKeyData.ext,
+              publicRsaJsonWebKeyData.key_ops
+            );
+            await crypto.subtle.verify(
+              createRsaJsonWebKeyAlgorithm(),
+              key,
+              undefined,
+              new Uint8Array()
+            );
+          },
+          Error,
+          'SubtleCrypto.verify: signature (argument 3) must be of type ArrayBuffer or ArrayBufferView but got ""'
+        );
+      });
+    }
+    // fourth-parameter
+    {
+      await t.test(
+        "subtle.verify.fourth-parameter-invalid-format",
+        async () => {
+          const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+          await rejects(
+            async () => {
+              const key = await crypto.subtle.importKey(
+                "jwk",
+                publicRsaJsonWebKeyData,
+                createRsaJsonWebKeyAlgorithm(),
+                publicRsaJsonWebKeyData.ext,
+                publicRsaJsonWebKeyData.key_ops
+              );
+              await crypto.subtle.verify(
+                createRsaJsonWebKeyAlgorithm(),
+                key,
+                new Uint8Array(),
+                undefined
+              );
+            },
+            Error,
+            'SubtleCrypto.verify: data (argument 4) must be of type ArrayBuffer or ArrayBufferView but got ""'
+          );
+        }
+      );
+    }
+    // incorrect-signature
+    {
+      await t.test("subtle.verify.incorrect-signature-jwk", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          publicRsaJsonWebKeyData,
+          createRsaJsonWebKeyAlgorithm(),
+          publicRsaJsonWebKeyData.ext,
+          publicRsaJsonWebKeyData.key_ops
+        );
+        const signature = new Uint8Array();
+        const enc = new TextEncoder();
+        const data = enc.encode("hello world");
+        const result = await crypto.subtle.verify(
+          createRsaJsonWebKeyAlgorithm(),
+          key,
+          signature,
+          data
+        );
+        strictEqual(result, false, "result === false");
+      });
+      await t.test("subtle.verify.incorrect-signature-hmac", async () => {
+        const keyUint8Array = new Uint8Array([1, 0, 1]);
+        const signature = new Uint8Array();
+        const enc = new TextEncoder();
+        const data = enc.encode("hello world");
+
+        for (const algorithm of ["SHA-1", "SHA-256", "SHA-384", "SHA-512"]) {
+          const key = await globalThis.crypto.subtle.importKey(
+            "raw",
+            keyUint8Array,
+            { name: "HMAC", hash: algorithm },
+            false,
+            ["sign", "verify"]
+          );
+          const result = await crypto.subtle.verify(
+            "HMAC",
+            key,
+            signature,
+            data
+          );
+          strictEqual(result, false, "result");
+        }
+      });
+    }
+    // correct-signature
+    {
+      await t.test("subtle.verify.correct-signature-jwk-rsa", async () => {
+        const publicRsaJsonWebKeyData = createPublicRsaJsonWebKeyData();
+        const privateRsaJsonWebKeyData = createPrivateRsaJsonWebKeyData();
+        const pkey = await crypto.subtle.importKey(
+          "jwk",
+          privateRsaJsonWebKeyData,
+          createRsaJsonWebKeyAlgorithm(),
+          privateRsaJsonWebKeyData.ext,
+          privateRsaJsonWebKeyData.key_ops
+        );
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          publicRsaJsonWebKeyData,
+          createRsaJsonWebKeyAlgorithm(),
+          publicRsaJsonWebKeyData.ext,
+          publicRsaJsonWebKeyData.key_ops
+        );
+        const enc = new TextEncoder();
+        const data = enc.encode("hello world");
+        const signature = await crypto.subtle.sign(
+          createRsaJsonWebKeyAlgorithm(),
+          pkey,
+          data
+        );
+        const result = await crypto.subtle.verify(
+          createRsaJsonWebKeyAlgorithm(),
+          key,
+          signature,
+          data
+        );
+        strictEqual(result, true, "result === true");
+      });
+      await t.test("subtle.verify.correct-signature-jwk-ecdsa", async () => {
+        const publicEcdsaJsonWebKeyData = createPublicEcdsaJsonWebKeyData();
+        const privateEcdsaJsonWebKeyData = createPrivateEcdsaJsonWebKeyData();
+        const pkey = await crypto.subtle.importKey(
+          "jwk",
+          privateEcdsaJsonWebKeyData,
+          ecdsaJsonWebKeyAlgorithm,
+          privateEcdsaJsonWebKeyData.ext,
+          privateEcdsaJsonWebKeyData.key_ops
+        );
+        const key = await crypto.subtle.importKey(
+          "jwk",
+          publicEcdsaJsonWebKeyData,
+          ecdsaJsonWebKeyAlgorithm,
+          publicEcdsaJsonWebKeyData.ext,
+          publicEcdsaJsonWebKeyData.key_ops
+        );
+        const enc = new TextEncoder();
+        const data = enc.encode("hello world");
+        const signature = await crypto.subtle.sign(
+          ecdsaJsonWebKeyAlgorithm,
+          pkey,
+          data
+        );
+        const result = await crypto.subtle.verify(
+          ecdsaJsonWebKeyAlgorithm,
+          key,
+          signature,
+          data
+        );
+        strictEqual(result, true, "result === true");
+      });
+      await t.test("subtle.verify.correct-signature-hmac", async () => {
+        const results = {
+          "SHA-1": new Uint8Array([
+            222, 61, 81, 133, 232, 89, 130, 225, 248, 25, 220, 34, 245, 103, 89,
+            127, 136, 77, 146, 166,
+          ]),
+          "SHA-256": new Uint8Array([
+            92, 237, 16, 210, 91, 89, 194, 36, 95, 98, 27, 175, 64, 25, 15, 160,
+            152, 178, 145, 235, 62, 92, 23, 202, 125, 228, 8, 25, 148, 26, 215,
+            242,
+          ]),
+          "SHA-384": new Uint8Array([
+            238, 20, 74, 173, 238, 236, 161, 229, 250, 167, 72, 210, 188, 239,
+            233, 39, 233, 166, 114, 241, 140, 229, 201, 129, 243, 173, 74, 198,
+            223, 145, 228, 96, 253, 91, 166, 111, 244, 23, 141, 62, 112, 156,
+            90, 166, 214, 69, 185, 48,
+          ]),
+          "SHA-512": new Uint8Array([
+            211, 127, 139, 149, 23, 225, 84, 230, 82, 249, 109, 254, 168, 236,
+            217, 112, 174, 52, 231, 62, 167, 197, 33, 11, 181, 21, 162, 236,
+            214, 132, 43, 161, 92, 112, 230, 182, 140, 69, 169, 229, 87, 98, 57,
+            81, 140, 134, 219, 253, 139, 169, 85, 181, 195, 195, 166, 241, 219,
+            33, 9, 56, 67, 213, 51, 224,
+          ]),
+        };
+        const encoder = new TextEncoder();
+        const messageUint8Array = encoder.encode("aki");
+        const keyUint8Array = new Uint8Array([1, 0, 1]);
+
+        for (const algorithm of ["SHA-1", "SHA-256", "SHA-384", "SHA-512"]) {
+          const key = await globalThis.crypto.subtle.importKey(
+            "raw",
+            keyUint8Array,
+            { name: "HMAC", hash: algorithm },
+            false,
+            ["sign", "verify"]
+          );
+          // Sign the message with HMAC and the CryptoKey
+          // const signature = new Uint8Array(await globalThis.crypto.subtle.sign("HMAC", key, messageUint8Array));
+          const signature = results[algorithm];
+          const result = await crypto.subtle.verify(
+            "HMAC",
+            key,
+            signature,
+            messageUint8Array
+          );
+          strictEqual(result, true, "result");
+        }
+      });
+    }
+  }
+});

--- a/tests/integration/handlers.js
+++ b/tests/integration/handlers.js
@@ -1,2 +1,3 @@
 export { handler as btoa } from './btoa/btoa.js';
+export { handler as crypto } from './crypto/crypto.js';
 export { handler as timers } from './timers/timers.js';

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -36,4 +36,5 @@ test_e2e(tla-err)
 test_e2e(tla-runtime-resolve)
 
 test_integration(btoa)
+test_integration(crypto)
 test_integration(timers)


### PR DESCRIPTION
This updates the crypto implementation with the PR in https://github.com/fastly/js-compute-runtime/pull/667 that was missed in the current implementation.

It also ports and verifies the full test suite is passing.