### PR TITLE
fix: patch for release build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,16 +22,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        mode: [debug, release]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
-
-    - name: Install Rust 1.68.2
-      run: |
-        rustup toolchain install 1.68.2
-        rustup target add wasm32-wasi --toolchain 1.68.2
 
     - uses: actions/setup-node@v2
       with:
@@ -39,9 +35,10 @@ jobs:
 
     - name: Build StarlingMonkey
       run: |
-        cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug
-        cmake --build cmake-build-debug --parallel 4 --target all integration-test-server
+        cmake -S . -B "cmake-build-${{matrix.mode}}" -DCMAKE_BUILD_TYPE=${{matrix.mode == 'debug' && 'Debug' || 'Release'}}
+        cmake --build cmake-build-${{matrix.mode}} --parallel 4 --target all integration-test-server
 
     - name: StarlingMonkey E2E & Integration Tests
       run: |
-        CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir cmake-build-debug -j4
+        CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir cmake-build-${{matrix.mode}} -j4
+      

--- a/cmake/spidermonkey.cmake
+++ b/cmake/spidermonkey.cmake
@@ -1,5 +1,10 @@
 set(SM_REV 702095ed0ba2316b4f2905bbd597d0b2fa23951e)
 
+CPMAddPackage(NAME spidermonkey-debug
+        URL https://github.com/bytecodealliance/spidermonkey-wasi-embedding/releases/download/rev_${SM_REV}/spidermonkey-wasm-static-lib_debug.tar.gz
+        DOWNLOAD_ONLY YES
+)
+
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(SM_BUILD_TYPE debug)
 else()
@@ -8,14 +13,9 @@ else()
         URL https://github.com/bytecodealliance/spidermonkey-wasi-embedding/releases/download/rev_${SM_REV}/spidermonkey-wasm-static-lib_release.tar.gz
         DOWNLOAD_ONLY YES
     )
+    # Temporary fix for https://github.com/bytecodealliance/StarlingMonkey/issues/50
+    file(COPY ${CPM_PACKAGE_spidermonkey-debug_SOURCE_DIR}/lib/libjsrust.a DESTINATION "${CPM_PACKAGE_spidermonkey-release_SOURCE_DIR}/lib")
 endif()
-
-CPMAddPackage(NAME spidermonkey-debug
-        URL https://github.com/bytecodealliance/spidermonkey-wasi-embedding/releases/download/rev_${SM_REV}/spidermonkey-wasm-static-lib_debug.tar.gz
-        DOWNLOAD_ONLY YES
-)
-
-file(COPY ${CPM_PACKAGE_spidermonkey-debug_SOURCE_DIR}/lib/libjsrust.a DESTINATION "${CPM_PACKAGE_spidermonkey-release_SOURCE_DIR}/lib")
 
 set(SM_SOURCE_DIR ${CPM_PACKAGE_spidermonkey-${SM_BUILD_TYPE}_SOURCE_DIR} CACHE STRING "Path to spidermonkey ${SM_BUILD_TYPE} build" FORCE)
 set(SM_INCLUDE_DIR ${SM_SOURCE_DIR}/include)

--- a/cmake/spidermonkey.cmake
+++ b/cmake/spidermonkey.cmake
@@ -4,12 +4,18 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(SM_BUILD_TYPE debug)
 else()
     set(SM_BUILD_TYPE release)
+    CPMAddPackage(NAME spidermonkey-release
+        URL https://github.com/bytecodealliance/spidermonkey-wasi-embedding/releases/download/rev_${SM_REV}/spidermonkey-wasm-static-lib_release.tar.gz
+        DOWNLOAD_ONLY YES
+    )
 endif()
 
-CPMAddPackage(NAME spidermonkey-${SM_BUILD_TYPE}
-        URL https://github.com/bytecodealliance/spidermonkey-wasi-embedding/releases/download/rev_${SM_REV}/spidermonkey-wasm-static-lib_${SM_BUILD_TYPE}.tar.gz
+CPMAddPackage(NAME spidermonkey-debug
+        URL https://github.com/bytecodealliance/spidermonkey-wasi-embedding/releases/download/rev_${SM_REV}/spidermonkey-wasm-static-lib_debug.tar.gz
         DOWNLOAD_ONLY YES
 )
+
+file(COPY ${CPM_PACKAGE_spidermonkey-debug_SOURCE_DIR}/lib/libjsrust.a DESTINATION "${CPM_PACKAGE_spidermonkey-release_SOURCE_DIR}/lib")
 
 set(SM_SOURCE_DIR ${CPM_PACKAGE_spidermonkey-${SM_BUILD_TYPE}_SOURCE_DIR} CACHE STRING "Path to spidermonkey ${SM_BUILD_TYPE} build" FORCE)
 set(SM_INCLUDE_DIR ${SM_SOURCE_DIR}/include)


### PR DESCRIPTION
After two days of running every build configuration change I can think of I just can't figure out the root cause of https://github.com/bytecodealliance/StarlingMonkey/issues/50.

I cloned spidermonkey-wasi-embedding and ran a release build against the same Rust toolchain used in js-compute-runtime and was able to get js-compute-runtime to build correctly against it. But StarlingMonkey just won't link against its libjsrust.a in release mode.

This implements a workaround that at least gets the release build to work, by copying the debug build's libjsrust.a instead. Perhaps it points to something in the StarlingMonkey configuration that isn't properly updating the Rust build to be a release instead of a debug build in the right way, I'm just not sure how duplicate function errors get determined in the linker and if it has anything to do with structural code similarity or not.

I'm going to stop running builds all day, and just use this patch. Help figuring out the root case on https://github.com/bytecodealliance/StarlingMonkey/issues/50 would be very welcome.