### PR TITLE
fix: release build on fetch rework

### DIFF
--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -1,6 +1,7 @@
 #include "host_api.h"
 #include "bindings/bindings.h"
 
+#include <set>
 #include <algorithm>
 #include <exports.h>
 #ifdef DEBUG
@@ -108,18 +109,29 @@ public:
   Handle take() {
     auto handle = get();
     // DBG("Consuming handle %d,%d\n", handle_ns_, handle);
+#ifdef DEBUG
     auto ns_handle = to_namespaced(handle, handle_ns_);
     used_handles.erase(ns_handle);
     poisoned_ = true;
+#endif
     return handle;
   }
 
-  bool valid() const { return handle_ != UNINITIALIZED_HANDLE && !poisoned_; }
+  bool valid() const {
+#ifdef DEBUG
+    if (posoned_) return false;
+#endif
+    return handle_ != UNINITIALIZED_HANDLE;
+  }
   bool initialized() const { return handle_ != UNINITIALIZED_HANDLE;}
+#ifdef DEBUG
   bool poisoned() const { return poisoned_; }
+#endif
 };
 
+#ifdef DEBUG
 std::set<int32_t> host_api::HandleState::used_handles = std::set<int32_t>();
+#endif
 
 namespace {
 

--- a/include/host_api.h
+++ b/include/host_api.h
@@ -335,6 +335,7 @@ public:
   virtual bool is_writable() { return false; };
   virtual HttpHeaders* as_writable() {
     MOZ_ASSERT_UNREACHABLE();
+    return nullptr;
   };
 
   Result<vector<tuple<HostString, HostString>>> entries() const;


### PR DESCRIPTION
I needed these changes to get the release build to work on https://github.com/bytecodealliance/StarlingMonkey/pull/52, but can confirm this works on js-compute-runtime and ComponentizeJS.