### PR TITLE
feat: single-tick non-tracking event loop runner

### DIFF
--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -990,10 +990,6 @@ bool reader_for_outgoing_body_catch_handler(JSContext *cx, JS::HandleObject body
   // `responseDone`. (Note that even though we encountered an error,
   // `responseDone` is the right state: `respondedWithError` is for when sending
   // a response at all failed.)
-  // TODO(TS): investigate why this is disabled.
-  // if (Response::is_instance(body_owner)) {
-  //   FetchEvent::set_state(FetchEvent::instance(), FetchEvent::State::responseDone);
-  // }
   return finish_outgoing_body_streaming(cx, body_owner);
 }
 

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -263,6 +263,18 @@ size_t api::AsyncTask::select(std::vector<AsyncTask *> &tasks) {
   return ready_index;
 }
 
+std::optional<size_t> api::AsyncTask::ready(std::vector<api::AsyncTask *> &tasks) {
+  auto count = tasks.size();
+  for (size_t idx = 0; idx < count; ++idx) {
+    auto task = tasks.at(idx);
+    WASIHandle<host_api::Pollable>::Borrowed poll = { task->id() };
+    if (wasi_io_0_2_0_poll_method_pollable_ready(poll)) {
+      return idx;
+    }
+  }
+  return std::nullopt;
+}
+
 namespace host_api {
 
 HostString::HostString(const char *c_str) {

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -149,6 +149,11 @@ public:
    * Select for the next available ready task, providing the oldest ready first.
    */
   static size_t select(std::vector<AsyncTask *> &handles);
+
+  /**
+   * Non-blocking check for a ready task, providing the oldest ready first, if any.
+   */
+  static std::optional<size_t> ready(std::vector<AsyncTask *> &handles);
 };
 
 } // namespace api


### PR DESCRIPTION
ComponentizeJS will run the event loop without interest as a way to ensure that async work is being done.

We do this in the post_call for functions so that the event loop is able to progress, without that affecting the primary exported function behaviour.

Certainly with async support this picture will change, but even with async support there is the concept I think this concept of "running a single tick" is useful.

The problem is that running a single tick does not do any task selection due to the risk of blocking. Thus, this PR implements a non-blocking `ready` call as an alternative to `select` in the specific situation when you are running the event loop without async interest explicitly registered. This allows things like timeouts and other events that aren't tracked to still complete when they are ready without causing unnecessary blocking.

I think this is a worthwhile use case for seeing https://github.com/WebAssembly/wasi-io/pull/75 implemented as well.