### PR TITLE
feat: support task deadlines

### DIFF
--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -68,6 +68,10 @@ public:
     return true;
   }
 
+  [[nodiscard]] uint64_t deadline(api::Engine *engine) override {
+    return deadline_;
+  }
+
   void trace(JSTracer *trc) override {
     TraceEdge(trc, &callback_, "Timer callback");
     for (auto &arg : arguments_) {

--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -68,7 +68,7 @@ public:
     return true;
   }
 
-  [[nodiscard]] uint64_t deadline(api::Engine *engine) override {
+  [[nodiscard]] uint64_t deadline() override {
     return deadline_;
   }
 

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -127,7 +127,7 @@ public:
     return handle_;
   }
 
-  [[nodiscard]] virtual uint64_t deadline(Engine *engine) {
+  [[nodiscard]] virtual uint64_t deadline() {
     return 0;
   }
 

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -127,6 +127,10 @@ public:
     return handle_;
   }
 
+  [[nodiscard]] virtual uint64_t deadline(Engine *engine) {
+    return 0;
+  }
+
   virtual void trace(JSTracer *trc) = 0;
 
   /**


### PR DESCRIPTION
Fastly's js-compute-runtime does not support timer subscriptions, and instead virtual timers are used which check their deadlines as part of the normal event loop operation.

This PR implements a concept of deadlines for all tasks, so that the host select implementation can use those deadlines to progress task deadlines for hosts without timing subscriptions.

Feedback very welcome. This is one of the last pieces needed for the migration to StarlingMonkey for js-compute-runtime, with the migration passing 99% of all other tests down to this feature.