### PR TITLE
refactor: select to take a tasks vector reference

### DIFF
--- a/host-apis/wasi-0.2.0-rc-2023-10-18/host_api.cpp
+++ b/host-apis/wasi-0.2.0-rc-2023-10-18/host_api.cpp
@@ -95,10 +95,10 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
-  auto count = tasks->size();
+size_t api::AsyncTask::select(std::vector<api::AsyncTask *> &tasks) {
+  auto count = tasks.size();
   vector<Borrow<Pollable>> handles;
-  for (const auto task : *tasks) {
+  for (const auto task : tasks) {
     handles.emplace_back(task->id());
   }
   auto list = list_borrow_pollable_t{

--- a/host-apis/wasi-0.2.0-rc-2023-12-05/host_api.cpp
+++ b/host-apis/wasi-0.2.0-rc-2023-12-05/host_api.cpp
@@ -99,10 +99,10 @@ template <> struct HandleOps<Pollable> {
 
 } // namespace
 
-size_t api::AsyncTask::select(std::vector<api::AsyncTask *> *tasks) {
-  auto count = tasks->size();
+size_t api::AsyncTask::select(std::vector<api::AsyncTask *> &tasks) {
+  auto count = tasks.size();
   vector<Borrow<Pollable>> handles;
-  for (const auto task : *tasks) {
+  for (const auto task : tasks) {
     handles.emplace_back(task->id());
   }
   auto list = list_borrow_pollable_t{

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -248,7 +248,7 @@ public:
 };
 
 size_t api::AsyncTask::select(std::vector<AsyncTask *> &tasks) {
-  auto count = tasks->size();
+  auto count = tasks.size();
   vector<WASIHandle<host_api::Pollable>::Borrowed> handles;
   for (const auto task : tasks) {
     handles.emplace_back(task->id());

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -247,10 +247,10 @@ public:
   }
 };
 
-size_t api::AsyncTask::select(std::vector<AsyncTask *> *tasks) {
+size_t api::AsyncTask::select(std::vector<AsyncTask *> &tasks) {
   auto count = tasks->size();
   vector<WASIHandle<host_api::Pollable>::Borrowed> handles;
-  for (const auto task : *tasks) {
+  for (const auto task : tasks) {
     handles.emplace_back(task->id());
   }
   auto list = list_borrow_pollable_t{ handles.data(), count};

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -147,7 +147,7 @@ public:
   /**
    * Select for the next available ready task, providing the oldest ready first.
    */
-  static size_t select(std::vector<AsyncTask *> *handles);
+  static size_t select(std::vector<AsyncTask *> &handles);
 };
 
 } // namespace api

--- a/runtime/event_loop.cpp
+++ b/runtime/event_loop.cpp
@@ -84,7 +84,7 @@ bool EventLoop::run_event_loop(api::Engine *engine, double total_compute) {
     }
 
     // Select the next task to run according to event-loop semantics of oldest-first.
-    size_t task_idx = api::AsyncTask::select(tasks);
+    size_t task_idx = api::AsyncTask::select(*tasks);
 
     auto task = tasks->at(task_idx);
     bool success = task->run(engine);


### PR DESCRIPTION
Updates the `HostApi::select` interface to take a reference to a vector instead of a pointer.