### PR TITLE
Improve handling of GC managed array buffers

### DIFF
--- a/builtins/web/crypto/crypto.cpp
+++ b/builtins/web/crypto/crypto.cpp
@@ -54,6 +54,7 @@ bool Crypto::get_random_values(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   auto res = host_api::Random::get_bytes(byte_length);
   if (auto *err = res.to_err()) {
+    noGC.reset();
     HANDLE_ERROR(cx, *err);
     return false;
   }

--- a/builtins/web/streams/compression-stream.cpp
+++ b/builtins/web/streams/compression-stream.cpp
@@ -129,7 +129,7 @@ bool deflate_chunk(JSContext *cx, JS::HandleObject self, JS::HandleValue chunk, 
 
       {
         bool is_shared;
-        JS::AutoCheckCannotGC nogc;
+        JS::AutoCheckCannotGC nogc(cx);
         uint8_t *out_buffer = JS_GetUint8ArrayData(out_obj, &is_shared, nogc);
         memcpy(out_buffer, buffer, bytes);
       }


### PR DESCRIPTION
Specifically, some of the `noGC` guards had issues that could lead to panics during exception throwing, and some of the loops over multiple buffers where overly complex.