### PR TITLE
timers: allow clearTimeout and clearInterval during initialization

### DIFF
--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -134,7 +134,6 @@ template <bool repeat> bool setTimeout_or_interval(JSContext *cx, const unsigned
  * https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-clearinterval
  */
 template <bool interval> bool clearTimeout_or_interval(JSContext *cx, unsigned argc, Value *vp) {
-  REQUEST_HANDLER_ONLY(interval ? "clearInterval" : "clearTimeout");
   const CallArgs args = CallArgsFromVp(argc, vp);
   if (!args.requireAtLeast(cx, interval ? "clearInterval" : "clearTimeout", 1)) {
     return false;


### PR DESCRIPTION
Strictly speaking, `clearTimeout` and `clearInterval` are valid noops when passed invalid values, therefore there is no reason to ban them at initialization time.

This behaviour is for some reason needed for Fastly's web platform test suite as well.

It does no harm, so I see no reason not to land this provided that `setTimeout` and `setInterval` remain protected.