### PR TITLE
Bugfixes for `setTimeout` and `setInterval`

### DIFF
--- a/runtime/event_loop.cpp
+++ b/runtime/event_loop.cpp
@@ -23,7 +23,10 @@ static PersistentRooted<TaskQueue> queue;
 
 namespace core {
 
-void EventLoop::queue_async_task(api::AsyncTask *task) { queue.get().tasks.emplace_back(task); }
+void EventLoop::queue_async_task(api::AsyncTask *task) {
+  MOZ_ASSERT(task);
+  queue.get().tasks.emplace_back(task);
+}
 
 bool EventLoop::cancel_async_task(api::Engine *engine, const int32_t id) {
   const auto tasks = &queue.get().tasks;
@@ -87,8 +90,8 @@ bool EventLoop::run_event_loop(api::Engine *engine, double total_compute) {
     size_t task_idx = api::AsyncTask::select(tasks);
 
     auto task = tasks->at(task_idx);
-    bool success = task->run(engine);
     tasks->erase(tasks->begin() + task_idx);
+    bool success = task->run(engine);
     if (!success) {
       exit_event_loop();
       return false;

--- a/tests/integration/test-server.js
+++ b/tests/integration/test-server.js
@@ -35,6 +35,21 @@ export function serveTest (handler) {
             curSubtest = null;
             subtestCnt++;
           }
+        },
+        async asyncTest (name, subtest) {
+          if (!filter(name))
+            return;
+          curSubtest = name;
+          let resolve, reject;
+          let promise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+          });
+          subtest(resolve, reject);
+          evt.waitUntil(promise);
+          await promise;
+          curSubtest = null;
+          subtestCnt++;
         }
       });
     }

--- a/tests/integration/timers/timers.js
+++ b/tests/integration/timers/timers.js
@@ -31,6 +31,12 @@ export const handler = serveTest(async (t) => {
       }
     });
   });
+  await t.asyncTest("setTimeout-cleared-in-callback", (resolve, reject) => {
+    let id = setTimeout.call(undefined, () => {
+      clearTimeout(id);
+      resolve();
+    }, 1);
+  });
   t.test("setInterval-exposed-as-global", () => {
     strictEqual(typeof setInterval, "function", `typeof setInterval`);
   });
@@ -341,6 +347,9 @@ export const handler = serveTest(async (t) => {
   });
   t.test("setTimeout-called-unbound", () => {
     setTimeout.call(undefined, () => {}, 1);
+  });
+  t.test("setTimeout-cleared-in-callback", () => {
+    let id = setTimeout.call(undefined, () => { clearTimeout(id); }, 1);
   });
 
   t.test("clearInterval-exposed-as-global", () => {

--- a/tests/integration/timers/timers.js
+++ b/tests/integration/timers/timers.js
@@ -2,34 +2,30 @@ import { serveTest } from "../test-server.js";
 import { assert, strictEqual, throws, deepStrictEqual } from "../assert.js";
 
 export const handler = serveTest(async (t) => {
-  await t.test("setTimeout", async () => {
+  await t.asyncTest("setTimeout-order", (resolve, reject) => {
     let first = false;
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        first = true;
-      }, 10);
-      setTimeout(() => {
-        try {
-          assert(first, 'first timeout should trigger first');
-        } catch (e) {
-          reject(e);
-          return;
-        }
-        resolve();
-      }, 20);
-    });
+    setTimeout(() => {
+      first = true;
+    }, 10);
+    setTimeout(() => {
+      try {
+        assert(first, 'first timeout should trigger first');
+      } catch (e) {
+        reject(e);
+        return;
+      }
+      resolve();
+    }, 20);
   });
-  await t.test("setInterval", async () => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        reject(new AssertionError("Expected setInterval to be called 10 times quickly"));
-      }, 1000);
-      let cnt = 0;
-      setInterval(() => {
-        cnt++;
-        if (cnt === 10)
-          resolve();
-      });
+  await t.asyncTest("setInterval-10-times", (resolve, reject) => {
+    setTimeout(() => {
+      reject(new AssertionError("Expected setInterval to be called 10 times quickly"));
+    }, 1000);
+    let cnt = 0;
+    setInterval(() => {
+      cnt++;
+      if (cnt === 10)
+        resolve();
     });
   });
   t.test("setInterval-exposed-as-global", () => {

--- a/tests/integration/timers/timers.js
+++ b/tests/integration/timers/timers.js
@@ -1,5 +1,5 @@
 import { serveTest } from "../test-server.js";
-import { assert, strictEqual, throws, deepStrictEqual } from "../assert.js";
+import { assert, strictEqual, throws, deepStrictEqual, AssertionError } from "../assert.js";
 
 export const handler = serveTest(async (t) => {
   await t.asyncTest("setTimeout-order", (resolve, reject) => {
@@ -18,14 +18,17 @@ export const handler = serveTest(async (t) => {
     }, 20);
   });
   await t.asyncTest("setInterval-10-times", (resolve, reject) => {
-    setTimeout(() => {
+    let timeout = setTimeout(() => {
       reject(new AssertionError("Expected setInterval to be called 10 times quickly"));
     }, 1000);
     let cnt = 0;
-    setInterval(() => {
+    let interval = setInterval(() => {
       cnt++;
-      if (cnt === 10)
+      if (cnt === 10) {
+        clearTimeout(timeout);
+        clearInterval(interval);
         resolve();
+      }
     });
   });
   t.test("setInterval-exposed-as-global", () => {


### PR DESCRIPTION
Before this patch, timer (i.e., `setTimeout`/`setInterval`) returned the pollable handles as IDs. This is problematic, because pollable handles are reused, leading to content potentially clearing the wrong timer.

Additionally, the code wasn't robust against a timer being cleared in its own callback, leading to a failing assertion.

I also added a few tweaks to the test code that I did while writing the test for this.