### PR TITLE
feat: allow direct base64 call against HandleValue

### DIFF
--- a/builtins/web/base64.cpp
+++ b/builtins/web/base64.cpp
@@ -5,7 +5,7 @@ namespace builtins {
 namespace web {
 namespace base64 {
 
-JS::Result<std::string> convertJSValueToByteString(JSContext *cx, JS::Handle<JS::Value> v) {
+JS::Result<std::string> valueToJSByteString(JSContext *cx, JS::Handle<JS::Value> v) {
   JS::RootedString s(cx);
   if (v.isString()) {
     s = v.toString();
@@ -54,10 +54,10 @@ JS::Result<std::string> convertJSValueToByteString(JSContext *cx, JS::Handle<JS:
   return byteString;
 }
 
-JS::Result<std::string> convertJSValueToByteString(JSContext *cx, std::string v) {
+JS::Result<std::string> stringToJSByteString(JSContext *cx, std::string v) {
   JS::RootedValue s(cx);
   s.setString(JS_NewStringCopyN(cx, v.c_str(), v.length()));
-  return convertJSValueToByteString(cx, s);
+  return valueToJSByteString(cx, s);
 }
 
 // Maps an encoded character to a value in the Base64 alphabet, per
@@ -295,7 +295,7 @@ bool atob(JSContext *cx, unsigned argc, Value *vp) {
   if (!args.requireAtLeast(cx, "atob", 1)) {
     return false;
   }
-  auto dataResult = convertJSValueToByteString(cx, args.get(0));
+  auto dataResult = valueToJSByteString(cx, args.get(0));
   if (dataResult.isErr()) {
     return false;
   }
@@ -405,7 +405,7 @@ bool btoa(JSContext *cx, unsigned argc, Value *vp) {
   // Note: We do not check if data contains any character whose code point is
   // greater than U+00FF before calling convertJSValueToByteString as
   // convertJSValueToByteString does the same check
-  auto byteStringResult = convertJSValueToByteString(cx, data);
+  auto byteStringResult = valueToJSByteString(cx, data);
   if (byteStringResult.isErr()) {
     return false;
   }

--- a/builtins/web/base64.h
+++ b/builtins/web/base64.h
@@ -17,6 +17,7 @@ extern const char base64URLEncodeTable[65];
 std::string forgivingBase64Encode(std::string_view data, const char *encodeTable);
 JS::Result<std::string> forgivingBase64Decode(std::string_view data, const uint8_t *decodeTable);
 
+JS::Result<std::string> convertJSValueToByteString(JSContext *cx, HandleValue v);
 JS::Result<std::string> convertJSValueToByteString(JSContext *cx, std::string v);
 
 } // namespace base64

--- a/builtins/web/base64.h
+++ b/builtins/web/base64.h
@@ -17,8 +17,8 @@ extern const char base64URLEncodeTable[65];
 std::string forgivingBase64Encode(std::string_view data, const char *encodeTable);
 JS::Result<std::string> forgivingBase64Decode(std::string_view data, const uint8_t *decodeTable);
 
-JS::Result<std::string> convertJSValueToByteString(JSContext *cx, HandleValue v);
-JS::Result<std::string> convertJSValueToByteString(JSContext *cx, std::string v);
+JS::Result<std::string> valueToJSByteString(JSContext *cx, HandleValue v);
+JS::Result<std::string> stringToJSByteString(JSContext *cx, std::string v);
 
 } // namespace base64
 } // namespace web

--- a/builtins/web/crypto/crypto-algorithm.cpp
+++ b/builtins/web/crypto/crypto-algorithm.cpp
@@ -166,7 +166,7 @@ std::unique_ptr<CryptoKeyRSAComponents> createRSAPublicKeyFromJWK(JSContext *cx,
   if (modulus.starts_with('0')) {
     modulus = modulus.erase(0, 1);
   }
-  auto dataResult = base64::convertJSValueToByteString(cx, jwk->e.value());
+  auto dataResult = base64::stringToJSByteString(cx, jwk->e.value());
   if (dataResult.isErr()) {
     DOMException::raise(cx, "Data provided to an operation does not meet requirements",
                         "DataError");
@@ -258,7 +258,7 @@ std::unique_ptr<CryptoKeyRSAComponents> createRSAPrivateKeyFromJWK(JSContext *cx
   if (modulus.starts_with('0')) {
     modulus = modulus.erase(0, 1);
   }
-  auto dataResult = base64::convertJSValueToByteString(cx, jwk->e.value());
+  auto dataResult = base64::stringToJSByteString(cx, jwk->e.value());
   if (dataResult.isErr()) {
     DOMException::raise(cx, "Data provided to an operation does not meet requirements",
                         "DataError");


### PR DESCRIPTION
Adds back the ability to call `convertJSValueToByteString` for a `HandleValue` by declaring the header for the original function variant. Necessary for Fastly's `statusText` setter to pass the web platform tests, because converting to a string first was altering unsupported characters.