### PR TITLE
fix: support non-unique handles for timers

### DIFF
--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -111,7 +111,7 @@ public:
       return false;
     }
 
-    ENGINE->remove_async_task(timer_ids_[timer_id]);
+    ENGINE->cancel_async_task(timer_ids_[timer_id]);
     timer_ids_.erase(timer_id);
     return true;
   }

--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -54,7 +54,7 @@ public:
 
     handle_ = host_api::MonotonicClock::subscribe(deadline_, true);
     timer_id_ = TIMERS_MAP->next_timer_id++;
-    TIMERS_MAP->timer_ids_.emplace(timer_id_, this);
+    TIMERS_MAP->timers_.emplace(timer_id_, this);
   }
 
   [[nodiscard]] bool run(api::Engine *engine) override {
@@ -81,13 +81,13 @@ public:
       host_api::MonotonicClock::unsubscribe(handle_);
     }
 
-    if (TIMERS_MAP->timer_ids_.contains(timer_id_)) {
+    if (TIMERS_MAP->timers_.contains(timer_id_)) {
       if (repeat_) {
         deadline_ = host_api::MonotonicClock::now() + delay_;
         handle_ = host_api::MonotonicClock::subscribe(deadline_, true);
         engine->queue_async_task(this);
       } else {
-        TIMERS_MAP->timer_ids_.erase(timer_id_);
+        TIMERS_MAP->timers_.erase(timer_id_);
       }
     }
 
@@ -95,7 +95,7 @@ public:
   }
 
   [[nodiscard]] bool cancel(api::Engine *engine) override {
-    if (!TIMERS_MAP->timer_ids_.contains(timer_id_)) {
+    if (!TIMERS_MAP->timers_.contains(timer_id_)) {
       return false;
     }
 
@@ -120,12 +120,12 @@ public:
   }
 
   static bool clear(int32_t timer_id) {
-    if (!TIMERS_MAP->timer_ids_.contains(timer_id)) {
+    if (!TIMERS_MAP->timers_.contains(timer_id)) {
       return false;
     }
 
-    ENGINE->cancel_async_task(TIMERS_MAP->timer_ids_[timer_id]);
-    TIMERS_MAP->timer_ids_.erase(timer_id);
+    ENGINE->cancel_async_task(TIMERS_MAP->timers_[timer_id]);
+    TIMERS_MAP->timers_.erase(timer_id);
     return true;
   }
 };

--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -27,7 +27,7 @@ public:
 
 }
 
-static PersistentRooted<TimersMap*> TIMERS_MAP;
+static PersistentRooted<js::UniquePtr<TimersMap>> TIMERS_MAP;
 static api::Engine *ENGINE;
 
 class TimerTask final : public api::AsyncTask {
@@ -208,7 +208,7 @@ constexpr JSFunctionSpec methods[] = {
 
 bool install(api::Engine *engine) {
   ENGINE = engine;
-  TIMERS_MAP.init(engine->cx(), new TimersMap());
+  TIMERS_MAP.init(engine->cx(), js::MakeUnique<TimersMap>());
   return JS_DefineFunctions(engine->cx(), engine->global(), methods);
 }
 

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -114,7 +114,7 @@ public:
 
   bool has_pending_async_tasks();
   void queue_async_task(AsyncTask *task);
-  bool remove_async_task(AsyncTask *task);
+  bool cancel_async_task(AsyncTask *task);
 
   void abort(const char *reason);
 

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -114,7 +114,7 @@ public:
 
   bool has_pending_async_tasks();
   void queue_async_task(AsyncTask *task);
-  bool cancel_async_task(int32_t id);
+  bool remove_async_task(AsyncTask *task);
 
   void abort(const char *reason);
 

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -506,6 +506,6 @@ bool api::Engine::debug_logging_enabled() { return ::debug_logging_enabled(); }
 bool api::Engine::has_pending_async_tasks() { return core::EventLoop::has_pending_async_tasks(); }
 
 void api::Engine::queue_async_task(AsyncTask *task) { core::EventLoop::queue_async_task(task); }
-bool api::Engine::remove_async_task(AsyncTask *task) {
-  return core::EventLoop::remove_async_task(this, task);
+bool api::Engine::cancel_async_task(AsyncTask *task) {
+  return core::EventLoop::cancel_async_task(this, task);
 }

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -506,6 +506,6 @@ bool api::Engine::debug_logging_enabled() { return ::debug_logging_enabled(); }
 bool api::Engine::has_pending_async_tasks() { return core::EventLoop::has_pending_async_tasks(); }
 
 void api::Engine::queue_async_task(AsyncTask *task) { core::EventLoop::queue_async_task(task); }
-bool api::Engine::cancel_async_task(int32_t id) {
-  return core::EventLoop::cancel_async_task(this, id);
+bool api::Engine::remove_async_task(AsyncTask *task) {
+  return core::EventLoop::remove_async_task(this, task);
 }

--- a/runtime/event_loop.cpp
+++ b/runtime/event_loop.cpp
@@ -28,7 +28,7 @@ void EventLoop::queue_async_task(api::AsyncTask *task) {
   queue.get().tasks.emplace_back(task);
 }
 
-bool EventLoop::remove_async_task(api::Engine *engine, api::AsyncTask *task) {
+bool EventLoop::cancel_async_task(api::Engine *engine, api::AsyncTask *task) {
   const auto tasks = &queue.get().tasks;
   for (auto it = tasks->begin(); it != tasks->end(); ++it) {
     if (*it == task) {

--- a/runtime/event_loop.cpp
+++ b/runtime/event_loop.cpp
@@ -28,13 +28,12 @@ void EventLoop::queue_async_task(api::AsyncTask *task) {
   queue.get().tasks.emplace_back(task);
 }
 
-bool EventLoop::cancel_async_task(api::Engine *engine, const int32_t id) {
+bool EventLoop::remove_async_task(api::Engine *engine, api::AsyncTask *task) {
   const auto tasks = &queue.get().tasks;
   for (auto it = tasks->begin(); it != tasks->end(); ++it) {
-    const auto task = *it;
-    if (task->id() == id) {
-      task->cancel(engine);
+    if (*it == task) {
       tasks->erase(it);
+      task->cancel(engine);
       return true;
     }
   }

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -46,7 +46,7 @@ public:
   /**
    * Remove a queued async task.
    */
-  static bool cancel_async_task(api::Engine *engine, int32_t id);
+  static bool remove_async_task(api::Engine *engine, api::AsyncTask *task);
 };
 
 } // namespace core

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -46,7 +46,7 @@ public:
   /**
    * Remove a queued async task.
    */
-  static bool remove_async_task(api::Engine *engine, api::AsyncTask *task);
+  static bool cancel_async_task(api::Engine *engine, api::AsyncTask *task);
 };
 
 } // namespace core


### PR DESCRIPTION
This was necessary to get one of the WPT cases to pass for Fastly's implementation.

Our implementation of checking task deadlines for timer tasks uses a redundant singular invalid handle (`-2`) to indicate a timer handle for a non-existent subscription. If we gave every timer a unique handle we would be using up the real handle ID space.

But the `cancel_task` currently assumes handle uniqueness when finding the handle.

This supports non-unique handles for tasks by taking the task itself to `cancel_task` instead of its handle to look it up from, storing timers as a map from timer ids to task pointers.

I can confirm this is working correctly in the WPT test case for Fastly.