### PR TITLE
fix: zero coercion timeout removal bug

### DIFF
--- a/builtins/web/timers.cpp
+++ b/builtins/web/timers.cpp
@@ -114,7 +114,7 @@ public:
 };
 
 std::map<int32_t, PollableHandle> TimerTask::timer_ids_ = {};
-int32_t TimerTask::next_timer_id = 0;
+int32_t TimerTask::next_timer_id = 1;
 
 namespace builtins::web::timers {
 

--- a/tests/integration/timers/timers.js
+++ b/tests/integration/timers/timers.js
@@ -2,6 +2,16 @@ import { serveTest } from "../test-server.js";
 import { assert, strictEqual, throws, deepStrictEqual, AssertionError } from "../assert.js";
 
 export const handler = serveTest(async (t) => {
+  await t.asyncTest("clearTimeout invalid", (resolve, reject) => {
+    // cleartimeout can be called with arbitrary stuff
+    clearTimeout('blah');
+
+    const dontDeleteTimeout = setTimeout(resolve, 100);
+
+    // null converts to zero, which must not delete a real timer
+    clearTimeout(null);
+  });
+
   await t.asyncTest("setTimeout-order", (resolve, reject) => {
     let first = false;
     setTimeout(() => {


### PR DESCRIPTION
This fixes a bug where `clearTimeout(null)` could clear a valid timeout if one existed at timer id `0`, by starting the timer ids from `1`. Affected a real web platform test!