### PR TITLE
add builtin includes to error headers

### DIFF
--- a/builtins/web/base64.cpp
+++ b/builtins/web/base64.cpp
@@ -1,5 +1,6 @@
 #include "base64.h"
 #include "mozilla/Try.h"
+#include "builtin.h"
 
 DEF_ERR(InvalidCharacterError, JSEXN_RANGEERR, "String contains an invalid character", 0)
 

--- a/builtins/web/fetch/fetch-errors.h
+++ b/builtins/web/fetch/fetch-errors.h
@@ -1,6 +1,8 @@
 #ifndef FETCH_ERRORS_H
 #define FETCH_ERRORS_H
 
+#include "builtin.h"
+
 namespace FetchErrors {
 DEF_ERR(FetchNetworkError, JSEXN_TYPEERR, "NetworkError when attempting to fetch resource", 0)
 DEF_ERR(InvalidRespondWithArg, JSEXN_TYPEERR, "FetchEvent#respondWith must be called with a Response "

--- a/builtins/web/streams/stream-errors.h
+++ b/builtins/web/streams/stream-errors.h
@@ -1,6 +1,8 @@
 #ifndef STREAM_ERRORS_H
 #define STREAM_ERRORS_H
 
+#include "builtin.h"
+
 namespace StreamErrors {
 DEF_ERR(CompressingChunkFailed, JSEXN_TYPEERR, "CompressionStream transform: error compressing chunk", 0)
 DEF_ERR(DecompressingChunkFailed, JSEXN_TYPEERR, "DecompressionStream transform: error decompressing chunk", 0)

--- a/builtins/web/text-codec/text-codec-errors.h
+++ b/builtins/web/text-codec/text-codec-errors.h
@@ -1,6 +1,8 @@
 #ifndef TEXT_CODEC_ERRORS_H
 #define TEXT_CODEC_ERRORS_H
 
+#include "builtin.h"
+
 namespace TextCodecErrors {
 DEF_ERR(FetchNetworkError, JSEXN_TYPEERR, "NetworkError when attempting to fetch resource", 0)
 DEF_ERR(InvalidEncoding, JSEXN_RANGEERR, "TextDecoder constructor: The given encoding is not supported.", 0)


### PR DESCRIPTION
Adds the `builtin.h` include to the new error header files so if they are included directly there aren't ordering issues.