### PR TITLE
fix: wasm32-wasi install for toolchain

### DIFF
--- a/cmake/init-corrosion.cmake
+++ b/cmake/init-corrosion.cmake
@@ -9,7 +9,7 @@ set(Rust_CARGO_TARGET_LINK_NATIVE_LIBS "")
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/rust-toolchain.toml" Rust_TOOLCHAIN REGEX "^channel ?=")
 string(REGEX MATCH "[0-9.]+" Rust_TOOLCHAIN "${Rust_TOOLCHAIN}")
 execute_process(COMMAND rustup toolchain install ${Rust_TOOLCHAIN})
-execute_process(COMMAND rustup target add wasm32-wasi)
+execute_process(COMMAND rustup target add --toolchain ${Rust_TOOLCHAIN} wasm32-wasi)
 
 CPMAddPackage("gh:corrosion-rs/corrosion#be76480232216a64f65e3b1d9794d68cbac6c690")
 string(TOLOWER ${Rust_CARGO_HOST_ARCH} HOST_ARCH)


### PR DESCRIPTION
We had a failed publish on Fastly due to a different toolchain being installed by default and not having the `wasm32-wasi` target loaded.

This adds an explicit `--toolchain` flag to the `rustup target add` command, which should avoid issues like that in future.