### PR TITLE
Fix bugs with streaming outgoing bodies

### DIFF
--- a/builtins/web/fetch/fetch-api.cpp
+++ b/builtins/web/fetch/fetch-api.cpp
@@ -68,7 +68,7 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
 
   bool streaming = false;
-  if (!RequestOrResponse::maybe_stream_body(cx, request_obj, &streaming)) {
+  if (!RequestOrResponse::maybe_stream_body(cx, request_obj, request, &streaming)) {
     return false;
   }
   if (streaming) {

--- a/builtins/web/fetch/request-response.h
+++ b/builtins/web/fetch/request-response.h
@@ -103,6 +103,7 @@ public:
    * to `true`.
    */
   static bool maybe_stream_body(JSContext *cx, JS::HandleObject body_owner,
+                                host_api::HttpOutgoingBodyOwner *destination,
                                 bool *requires_streaming);
 
   static JSObject *create_body_stream(JSContext *cx, JS::HandleObject owner);

--- a/tests/e2e/stream-forwarding/expect_serve_body.txt
+++ b/tests/e2e/stream-forwarding/expect_serve_body.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/tests/e2e/stream-forwarding/stream-forwarding.js
+++ b/tests/e2e/stream-forwarding/stream-forwarding.js
@@ -1,0 +1,29 @@
+addEventListener('fetch', async (event) => {
+  try {
+    if (event.request.url.endsWith('/nested')) {
+      let encoder = new TextEncoder();
+      let body = new TransformStream({
+        start(controller) {
+        },
+        transform(chunk, controller) {
+          controller.enqueue(encoder.encode(chunk));
+        },
+        flush(controller) {
+        }
+      });
+      let writer = body.writable.getWriter();
+      event.respondWith(new Response(body.readable));
+      await writer.write('hello\n');
+      await writer.write('world\n');
+      writer.close();
+      return;
+    }
+
+    let resolve;
+    event.respondWith(new Promise((r) => resolve = r));
+    let response = await fetch(event.request.url + 'nested');
+    resolve(new Response(response.body, response));
+  } catch (e) {
+    console.error(e);
+  }
+});


### PR DESCRIPTION
This fixes a crashing bug in a trivial scenario: `event.respondWith(new Response(someUpstreamResponse.body, someUpstreamResponse);`

It's not entirely clear to me why WPT didn't catch this, though it's possible that the tests that would've done so abort early for trivial reasons, such as our missing `FormData` support.

Instead, I added an e2e test to cover this, which fails without this patch.

(There are small unrelated tweaks to the runtime-eval support which I applied in debugging the test.)