### PR TITLE
CMake build: do not strip component-related custom sections in non-wasm-opt config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ else()
         add_custom_command(
             TARGET starling.wasm
             POST_BUILD
-            COMMAND ${WASM_TOOLS_BIN} strip -a -o starling.wasm starling.wasm
+            COMMAND ${WASM_OPT} --strip-debug -O0 -o starling.wasm starling.wasm
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     endif()


### PR DESCRIPTION
In #89, I had added an alternative (under `USE_WASM_OPT=OFF`) to avoid expensive wasm-opt runs for local development. However I had replaced this with `wasm-tools strip`, which strips all custom sections, including those important for component-related linkage. Getting further along my integration path I discovered the world info for the module was missing.

This PR instead uses `wasm-opt -O0 --strip-debug`, which does what I want (using the same tool as the ordinary build path) without the expensive opt passes.