### PR TITLE
fix: providing a custom WPT_ROOT env var

### DIFF
--- a/tests/wpt-harness/wpt.cmake
+++ b/tests/wpt-harness/wpt.cmake
@@ -2,8 +2,8 @@ enable_testing()
 
 include("wasmtime")
 
-if(DEFINED $ENV{WPT_ROOT})
-    set(WPT_ROOT $ENV{WPT_ROOT})
+if(DEFINED ENV{WPT_ROOT})
+    set(WPT_ROOT ENV{WPT_ROOT})
 else()
 	CPMAddPackage(
 	  NAME wpt-suite


### PR DESCRIPTION
As identified by @cfallin this fixes the `WPT_ROOT` environment variable to be correctly referenced.