### PR TITLE
gc: add finalization for URL

### DIFF
--- a/builtins/web/url.cpp
+++ b/builtins/web/url.cpp
@@ -580,6 +580,11 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_
   return create(cx, self, url_val, base);
 }
 
+void URL::finalize(JS::GCContext *gcx, JSObject *self) {
+  jsurl::JSUrl* url = static_cast<jsurl::JSUrl *>(JS::GetReservedSlot(self, Slots::Url).toPrivate());
+  free(url);
+}
+
 JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_val,
                       JS::HandleValue base_val) {
   if (is_instance(base_val)) {

--- a/builtins/web/url.h
+++ b/builtins/web/url.h
@@ -131,6 +131,7 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+  static void finalize(JS::GCContext* gcx, JSObject *obj);
 };
 
 bool install(api::Engine *engine);

--- a/builtins/web/url.h
+++ b/builtins/web/url.h
@@ -64,7 +64,7 @@ public:
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 };
 
-class URL : public BuiltinImpl<URL> {
+class URL : public FinalizableBuiltinImpl<URL> {
   static bool hash_set(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool host_set(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool hostname_set(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -131,7 +131,7 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
-  static void finalize(JS::GCContext* gcx, JSObject *obj);
+  static void finalize(JS::GCContext *gcx, JSObject *obj);
 };
 
 bool install(api::Engine *engine);

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -177,8 +177,19 @@ inline bool ThrowIfNotConstructing(JSContext *cx, const CallArgs &args, const ch
 namespace builtins {
 
 template <typename Impl> class BuiltinImpl {
-  static constexpr JSClassOps class_ops{};
-  static constexpr uint32_t class_flags = 0;
+  static constexpr JSClassOps class_ops{
+    nullptr,                      // addProperty
+    nullptr,                      // delProperty
+    nullptr,                      // enumerate
+    nullptr,                      // newEnumerate
+    nullptr,                      // resolve
+    nullptr,                      // mayResolve
+    Impl::finalize,               // finalize
+    nullptr,                      // call
+    nullptr,                      // construct
+    nullptr,                      // trace
+  };
+  static constexpr uint32_t class_flags = JSCLASS_FOREGROUND_FINALIZE;
 
 public:
   static constexpr JSClass class_{
@@ -228,6 +239,8 @@ public:
 
     return proto_obj != nullptr;
   }
+
+  static void finalize(JS::GCContext* gcx, JSObject* obj) {}
 };
 
 template <typename Impl> PersistentRooted<JSObject *> BuiltinImpl<Impl>::proto_obj{};

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -50,8 +50,8 @@ using JS::PersistentRooted;
 std::optional<std::span<uint8_t>> value_to_buffer(JSContext *cx, HandleValue val,
                                                   const char *val_desc);
 
-#define DEF_ERR(name, exception, format, count) \
-static constexpr JSErrorFormatString name = { #name, format, count, exception };
+#define DEF_ERR(name, exception, format, count)                                                    \
+  static constexpr JSErrorFormatString name = {#name, format, count, exception};
 
 namespace api {
 #include "errors.h"
@@ -123,39 +123,39 @@ void markWizeningAsFinished();
   BUILTIN_ITERATOR_METHOD(class_name, keys, ITER_TYPE_KEYS)                                        \
   BUILTIN_ITERATOR_METHOD(class_name, values, ITER_TYPE_VALUES)                                    \
                                                                                                    \
-bool class_name::forEach(JSContext *cx, unsigned argc, JS::Value *vp) {                            \
-  METHOD_HEADER(1)                                                                                 \
-  if (!args[0].isObject() || !JS::IsCallable(&args[0].toObject())) {                               \
-    return api::throw_error(cx, api::Errors::ForEachCallback, #class_name);                        \
-  }                                                                                                \
-  JS::RootedValueArray<3> newArgs(cx);                                                             \
-  newArgs[2].setObject(*self);                                                                     \
-  JS::RootedValue rval(cx);                                                                        \
-  JS::RootedObject iter(cx, class_name##Iterator::create(cx, self, ITER_TYPE_ENTRIES));            \
-  if (!iter)                                                                                       \
-    return false;                                                                                  \
-  JS::RootedValue iterable(cx, ObjectValue(*iter));                                                \
-  JS::ForOfIterator it(cx);                                                                        \
-  if (!it.init(iterable))                                                                          \
-    return false;                                                                                  \
-                                                                                                   \
-  JS::RootedValue entry_val(cx);                                                                   \
-  JS::RootedObject entry(cx);                                                                      \
-  while (true) {                                                                                   \
-    bool done;                                                                                     \
-    if (!it.next(&entry_val, &done))                                                               \
+  bool class_name::forEach(JSContext *cx, unsigned argc, JS::Value *vp) {                          \
+    METHOD_HEADER(1)                                                                               \
+    if (!args[0].isObject() || !JS::IsCallable(&args[0].toObject())) {                             \
+      return api::throw_error(cx, api::Errors::ForEachCallback, #class_name);                      \
+    }                                                                                              \
+    JS::RootedValueArray<3> newArgs(cx);                                                           \
+    newArgs[2].setObject(*self);                                                                   \
+    JS::RootedValue rval(cx);                                                                      \
+    JS::RootedObject iter(cx, class_name##Iterator::create(cx, self, ITER_TYPE_ENTRIES));          \
+    if (!iter)                                                                                     \
       return false;                                                                                \
-    if (done)                                                                                      \
-      break;                                                                                       \
-                                                                                                   \
-    entry = &entry_val.toObject();                                                                 \
-    JS_GetElement(cx, entry, 1, newArgs[0]);                                                       \
-    JS_GetElement(cx, entry, 0, newArgs[1]);                                                       \
-    if (!JS::Call(cx, args.thisv(), args[0], newArgs, &rval))                                      \
+    JS::RootedValue iterable(cx, ObjectValue(*iter));                                              \
+    JS::ForOfIterator it(cx);                                                                      \
+    if (!it.init(iterable))                                                                        \
       return false;                                                                                \
-  }                                                                                                \
-  return true;                                                                                     \
-}
+                                                                                                   \
+    JS::RootedValue entry_val(cx);                                                                 \
+    JS::RootedObject entry(cx);                                                                    \
+    while (true) {                                                                                 \
+      bool done;                                                                                   \
+      if (!it.next(&entry_val, &done))                                                             \
+        return false;                                                                              \
+      if (done)                                                                                    \
+        break;                                                                                     \
+                                                                                                   \
+      entry = &entry_val.toObject();                                                               \
+      JS_GetElement(cx, entry, 1, newArgs[0]);                                                     \
+      JS_GetElement(cx, entry, 0, newArgs[1]);                                                     \
+      if (!JS::Call(cx, args.thisv(), args[0], newArgs, &rval))                                    \
+        return false;                                                                              \
+    }                                                                                              \
+    return true;                                                                                   \
+  }
 
 #define REQUEST_HANDLER_ONLY(name)                                                                 \
   if (isWizening()) {                                                                              \
@@ -177,19 +177,8 @@ inline bool ThrowIfNotConstructing(JSContext *cx, const CallArgs &args, const ch
 namespace builtins {
 
 template <typename Impl> class BuiltinImpl {
-  static constexpr JSClassOps class_ops{
-    nullptr,                      // addProperty
-    nullptr,                      // delProperty
-    nullptr,                      // enumerate
-    nullptr,                      // newEnumerate
-    nullptr,                      // resolve
-    nullptr,                      // mayResolve
-    Impl::finalize,               // finalize
-    nullptr,                      // call
-    nullptr,                      // construct
-    nullptr,                      // trace
-  };
-  static constexpr uint32_t class_flags = JSCLASS_FOREGROUND_FINALIZE;
+  static constexpr JSClassOps class_ops{};
+  static constexpr uint32_t class_flags = 0;
 
 public:
   static constexpr JSClass class_{
@@ -240,7 +229,23 @@ public:
     return proto_obj != nullptr;
   }
 
-  static void finalize(JS::GCContext* gcx, JSObject* obj) {}
+  static void finalize(JS::GCContext *gcx, JSObject *obj) {}
+};
+
+template <typename Impl> class FinalizableBuiltinImpl : public BuiltinImpl<Impl> {
+  static constexpr JSClassOps class_ops{
+      nullptr,        // addProperty
+      nullptr,        // delProperty
+      nullptr,        // enumerate
+      nullptr,        // newEnumerate
+      nullptr,        // resolve
+      nullptr,        // mayResolve
+      Impl::finalize, // finalize
+      nullptr,        // call
+      nullptr,        // construct
+      nullptr,        // trace
+  };
+  static constexpr uint32_t class_flags = JSCLASS_BACKGROUND_FINALIZE;
 };
 
 template <typename Impl> PersistentRooted<JSObject *> BuiltinImpl<Impl>::proto_obj{};


### PR DESCRIPTION
This is a first attempt to fix https://github.com/bytecodealliance/StarlingMonkey/issues/101 for further feedback.

In testing, I'm still not able to get the finalizer to run, as I believe we disable the GC during runtime still.

That said, supporting the GC running for long-running executions, and coding to avoid memory leaks still seem like important properties to retain for the runtime in general, even if not used.

@tschneidereit would very much value your feedback further here.