### PR TITLE
Support an `exit_event_loop()` function

### DIFF
--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -91,6 +91,11 @@ public:
   bool run_event_loop();
 
   /**
+   * Stop running the event loop as soon as possible, regardless of interest.
+   */
+  void exit_event_loop();
+
+  /**
    * Add an event loop interest to track
    */
   void incr_event_loop_interest();

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -482,6 +482,10 @@ bool api::Engine::run_event_loop() {
   return core::EventLoop::run_event_loop(this, 0);
 }
 
+void api::Engine::exit_event_loop() {
+  core::EventLoop::exit_event_loop();
+}
+
 void api::Engine::incr_event_loop_interest() {
   return core::EventLoop::incr_event_loop_interest();
 }

--- a/runtime/event_loop.h
+++ b/runtime/event_loop.h
@@ -30,6 +30,11 @@ public:
    */
   static bool run_event_loop(api::Engine *engine, double total_compute);
 
+  /**
+   * Stops running the event loop as soon as possible, regardless of interest.
+   */
+  static void exit_event_loop();
+
   static void incr_event_loop_interest();
   static void decr_event_loop_interest();
 


### PR DESCRIPTION
This works similarly to something like an `exit()` call where it implies that the process is done and that we no longer need to spin on async tasks.

This seems to make sense to me in that promise interest is about determining event loop completion, which may result in stalls before the response, while exiting accepts that any previously in-progress tasks may be abandoned, no matter how much interest they previously had.

Would be great to discuss further.