### PR TITLE
ci: add WPT debug build, fix streams assertion failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
     name: Web Platform Tests
     strategy:
       matrix:
-        build: [release]
+        build: [release, debug]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/builtins/web/streams/transform-stream.cpp
+++ b/builtins/web/streams/transform-stream.cpp
@@ -280,6 +280,9 @@ void TransformStream::set_owner(JSObject *self, JSObject *owner) {
 
 JSObject *TransformStream::readable(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
+  if (!JS::GetReservedSlot(self, TransformStream::Slots::Readable).isObject()) {
+    return nullptr;
+  }
   return &JS::GetReservedSlot(self, TransformStream::Slots::Readable).toObject();
 }
 
@@ -323,6 +326,9 @@ void TransformStream::set_readable_used_as_body(JSContext *cx, JS::HandleObject 
 
 JSObject *TransformStream::writable(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
+  if (!JS::GetReservedSlot(self, TransformStream::Slots::Writable).isObject()) {
+    return nullptr;
+  }
   return &JS::GetReservedSlot(self, TransformStream::Slots::Writable).toObject();
 }
 
@@ -372,13 +378,21 @@ void TransformStream::set_used_as_mixin(JSObject *self) {
 
 bool TransformStream::readable_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER_WITH_NAME(0, "get readable")
-  args.rval().setObject(*readable(self));
+  auto readable_val = readable(self);
+  // TODO: determine why this isn't being set in some cases
+  if (readable_val) {
+    args.rval().setObject(*readable_val);
+  }
   return true;
 }
 
 bool TransformStream::writable_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER_WITH_NAME(0, "get writable")
-  args.rval().setObject(*writable(self));
+  auto writable_val = writable(self);
+  // TODO: determine why this isn't being set in some cases
+  if (writable_val) {
+    args.rval().setObject(*writable_val);
+  }
   return true;
 }
 


### PR DESCRIPTION
This adds a CI job for the debug build on WPT, and also fixes an assertion failure which looks like a bug in transform streams.

I've posted a separate issue for this bug in https://github.com/bytecodealliance/StarlingMonkey/issues/112 to be resolved separately.

Necessary for Fastly's WPT to pass for the debug build.