### PR TITLE
BUG: test case for fetch encoding issue

### DIFF
--- a/tests/integration/fetch/fetch.js
+++ b/tests/integration/fetch/fetch.js
@@ -53,4 +53,9 @@ export const handler = serveTest(async (t) => {
     await request.text();
     throws(() => request.clone());
   });
+
+  await t.test('google encoding issue', async () => {
+    const res = await fetch('https://www.google.com');
+    await res.text();
+  });
 });


### PR DESCRIPTION
This replicates the original failure I was having testing out `fetch` for ComponentizeJS. It turns out it is a content encoding issue when the test website is `google.com`.

The replication here just does a simple `await fetch('https://www.google.com')` which then gets the following error:

```
HTTP/1.1 500 Internal Server Error
content-length: 116
content-type: text/plain;charset=UTF-8
date: Wed, 28 Aug 2024 18:26:25 GMT

Error running test fetch?google encoding issue
Unexpected error: malformed UTF-8 character sequence at offset 48854
```