### PR TITLE
Update to weval 0.2.11.

### DIFF
--- a/cmake/weval.cmake
+++ b/cmake/weval.cmake
@@ -1,4 +1,4 @@
-set(WEVAL_VERSION v0.2.9)
+set(WEVAL_VERSION v0.2.11)
 
 set(WEVAL_URL https://github.com/cfallin/weval/releases/download/${WEVAL_VERSION}/weval-${WEVAL_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
 CPMAddPackage(NAME weval URL ${WEVAL_URL} DOWNLOAD_ONLY TRUE)


### PR DESCRIPTION
This includes the [Reducifier](https://github.com/cfallin/waffle/pull/13) in waffle (the compiler library underlying weval), which supports compiling irreducible control flow to Wasm. It should address any corner cases where weval'ing PBL with bytecode produces irreducible control flow.