### PR TITLE
Update to weval 0.2.12.

### DIFF
--- a/cmake/weval.cmake
+++ b/cmake/weval.cmake
@@ -1,4 +1,4 @@
-set(WEVAL_VERSION v0.2.11)
+set(WEVAL_VERSION v0.2.12)
 
 set(WEVAL_URL https://github.com/cfallin/weval/releases/download/${WEVAL_VERSION}/weval-${WEVAL_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
 CPMAddPackage(NAME weval URL ${WEVAL_URL} DOWNLOAD_ONLY TRUE)


### PR DESCRIPTION
This pulls in some follow-up fixes to the earlier 0.2.11 upgrade (#140): the irreducibility check is now precise rather than approximate, so it doesn't trigger unnecessarily, and part of the transform (the max-SSA bit) is rewritten to use an explicit stack rather than recursion so as not to overflow the stack in extreme cases when it does run.