### PR TITLE
Update to weval 0.2.14.

### DIFF
--- a/cmake/weval.cmake
+++ b/cmake/weval.cmake
@@ -1,4 +1,4 @@
-set(WEVAL_VERSION v0.2.12)
+set(WEVAL_VERSION v0.2.14)
 
 set(WEVAL_URL https://github.com/cfallin/weval/releases/download/${WEVAL_VERSION}/weval-${WEVAL_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
 CPMAddPackage(NAME weval URL ${WEVAL_URL} DOWNLOAD_ONLY TRUE)


### PR DESCRIPTION
This updates to refer to a new version of weval that has a CI fix so that Intel Macs get x86-64 binaries, not aarch64 binaries.