### PR TITLE
Update to weval 0.3.2.

### DIFF
--- a/cmake/weval.cmake
+++ b/cmake/weval.cmake
@@ -1,6 +1,6 @@
-set(WEVAL_VERSION v0.2.14)
+set(WEVAL_VERSION v0.3.2)
 
-set(WEVAL_URL https://github.com/cfallin/weval/releases/download/${WEVAL_VERSION}/weval-${WEVAL_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
+set(WEVAL_URL https://github.com/bytecodealliance/weval/releases/download/${WEVAL_VERSION}/weval-${WEVAL_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
 CPMAddPackage(NAME weval URL ${WEVAL_URL} DOWNLOAD_ONLY TRUE)
 set(WEVAL_DIR ${CPM_PACKAGE_weval_SOURCE_DIR})
 set(WEVAL_BIN ${WEVAL_DIR}/weval)


### PR DESCRIPTION
This pulls in the latest changes, which mainly revolve around moving weval into place as a Bytecode Alliance Hosted Project, at its new repository at
[bytecodealliance/weval](https://github.com/bytecodealliance/weval).