### PR TITLE
fix: keep names section under RelWithDebInfo build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (USE_WASM_OPT)
         add_custom_command(
                 TARGET starling.wasm
                 POST_BUILD
-                COMMAND ${WASM_OPT} --strip-debug -O3 -o starling.wasm starling.wasm
+                COMMAND ${WASM_OPT} --strip-debug -O3 -g -o starling.wasm starling.wasm
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,14 +67,14 @@ if (USE_WASM_OPT)
         add_custom_command(
                 TARGET starling.wasm
                 POST_BUILD
-                COMMAND ${WASM_OPT} --strip-debug -O3 -g -o starling.wasm starling.wasm
+                COMMAND ${WASM_OPT} --strip-debug -O3 -o starling.wasm starling.wasm
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
         add_custom_command(
                 TARGET starling.wasm
                 POST_BUILD
-                COMMAND ${WASM_OPT} -O3 -o starling.wasm starling.wasm
+                COMMAND ${WASM_OPT} -O3 -g -o starling.wasm starling.wasm
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     endif()


### PR DESCRIPTION
This ensures that `wasm-opt` does not strip the `"name"` section under `RelWithDebugInfo` builds (needed for ComponentizeJS).