### PR TITLE
fix: implement the finalizer pattern for the Headers builtin

### DIFF
--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -1015,6 +1015,21 @@ bool Headers::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+void Headers::finalize(JS::GCContext *gcx, JSObject *self) {
+  HeadersList *list = static_cast<HeadersList *>(
+      JS::GetReservedSlot(self, static_cast<size_t>(Headers::Slots::HeadersList)).toPrivate());
+  if (list != nullptr) {
+    list->clear();
+    free(list);
+  }
+  HeadersSortList *sort_list = static_cast<HeadersSortList *>(
+      JS::GetReservedSlot(self, static_cast<size_t>(Slots::HeadersSortList)).toPrivate());
+  if (sort_list != nullptr) {
+    sort_list->clear();
+    free(sort_list);
+  }
+}
+
 bool Headers::init_class(JSContext *cx, JS::HandleObject global) {
   // get the host forbidden headers for guard checks
   forbidden_request_headers = &host_api::HttpHeaders::get_forbidden_request_headers();

--- a/builtins/web/fetch/headers.h
+++ b/builtins/web/fetch/headers.h
@@ -8,7 +8,7 @@ namespace builtins {
 namespace web {
 namespace fetch {
 
-class Headers final : public BuiltinImpl<Headers> {
+class Headers final : public FinalizableBuiltinImpl<Headers> {
   static bool append(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool delete_(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool entries(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -126,6 +126,8 @@ public:
   static JSObject *create(JSContext *cx, HeadersGuard guard);
   static JSObject *create(JSContext *cx, HandleValue init_headers, HeadersGuard guard);
   static JSObject *create(JSContext *cx, host_api::HttpHeadersReadOnly *handle, HeadersGuard guard);
+
+  static void finalize(JS::GCContext *gcx, JSObject *obj);
 
   static bool init_entries(JSContext *cx, HandleObject self, HandleValue init_headers);
 

--- a/builtins/web/url.cpp
+++ b/builtins/web/url.cpp
@@ -581,7 +581,8 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_
 }
 
 void URL::finalize(JS::GCContext *gcx, JSObject *self) {
-  jsurl::JSUrl* url = static_cast<jsurl::JSUrl *>(JS::GetReservedSlot(self, Slots::Url).toPrivate());
+  jsurl::JSUrl *url =
+      static_cast<jsurl::JSUrl *>(JS::GetReservedSlot(self, Slots::Url).toPrivate());
   free(url);
 }
 


### PR DESCRIPTION
This implements the GC finalization for the `Headers` builtin, disposing the private vectors correctly.