### PR TITLE
fix: componentize script to use local bins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ function(componentize OUTPUT)
     add_custom_command(
             OUTPUT ${OUTPUT}.wasm
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMAND ${CMAKE_COMMAND} -E env "PATH=${WASM_TOOLS_DIR};${WIZER_DIR};$ENV{PATH}" ${RUNTIME_DIR}/componentize.sh ${SOURCES} -o ${OUTPUT}.wasm
+            COMMAND ${CMAKE_COMMAND} ${RUNTIME_DIR}/componentize.sh ${SOURCES} -o ${OUTPUT}.wasm
             DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling.wasm
             VERBATIM
     )

--- a/componentize.sh
+++ b/componentize.sh
@@ -2,8 +2,8 @@
 
 #set -euo pipefail
 
-wizer="${WIZER:-wizer}"
-wasm_tools="${WASM_TOOLS:-wasm-tools}"
+wizer="${WIZER:-@WIZER_BIN@}"
+wasm_tools="${WASM_TOOLS:-@WASM_TOOLS_BIN@}"
 weval="${WEVAL:-@WEVAL_BIN@}"
 aot=@AOT@
 preopen_dir="${PREOPEN_DIR:-}"

--- a/componentize.sh
+++ b/componentize.sh
@@ -2,7 +2,7 @@
 
 #set -euo pipefail
 
-wizer="${WIZER:-@WIZER_BIN@}"
+wizer="${WIZER:-@WIZER_DIR@/wizer}"
 wasm_tools="${WASM_TOOLS:-@WASM_TOOLS_BIN@}"
 weval="${WEVAL:-@WEVAL_BIN@}"
 aot=@AOT@


### PR DESCRIPTION
This fixes the `componentize.sh` script to instead reference the locally installed toolchain, removing the need to have Wizer and wasm-tools in path.