### PR TITLE
Make starling.wasm a usable component, and document it as such

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (ENABLE_WPT)
     include("tests/wpt-harness/wpt.cmake")
 endif()
 
-add_executable(starling.wasm
+add_executable(starling-raw.wasm
         runtime/js.cpp
         runtime/allocator.cpp
         runtime/encode.cpp
@@ -65,31 +65,31 @@ option(USE_WASM_OPT "use wasm-opt to optimize the StarlingMonkey binary" ON)
 if (USE_WASM_OPT)
     if (CMAKE_BUILD_TYPE STREQUAL "Release")
         add_custom_command(
-                TARGET starling.wasm
+                TARGET starling-raw.wasm
                 POST_BUILD
-                COMMAND ${WASM_OPT} --strip-debug -O3 -o starling.wasm starling.wasm
+                COMMAND ${WASM_OPT} --strip-debug -O3 -o starling-raw.wasm starling-raw.wasm
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
         add_custom_command(
-                TARGET starling.wasm
+                TARGET starling-raw.wasm
                 POST_BUILD
-                COMMAND ${WASM_OPT} -O3 -g -o starling.wasm starling.wasm
+                COMMAND ${WASM_OPT} -O3 -g -o starling-raw.wasm starling-raw.wasm
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     endif()
 else()
     if (CMAKE_BUILD_TYPE STREQUAL "Release")
         add_custom_command(
-            TARGET starling.wasm
+            TARGET starling-raw.wasm
             POST_BUILD
-            COMMAND ${WASM_OPT} --strip-debug -O0 -o starling.wasm starling.wasm
+            COMMAND ${WASM_OPT} --strip-debug -O0 -o starling-raw.wasm starling-raw.wasm
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     endif()
 endif()
 
-target_link_libraries(starling.wasm PRIVATE host_api extension_api builtins spidermonkey rust-url)
+target_link_libraries(starling-raw.wasm PRIVATE host_api extension_api builtins spidermonkey rust-url)
 
 # build a compilation cache of ICs
 if(WEVAL)
@@ -100,8 +100,8 @@ if(WEVAL)
         ALL
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND rm -f starling-ics.wevalcache
-        COMMAND echo ./null.js | ${WEVAL_BIN} weval --dir . --show-stats --cache starling-ics.wevalcache -w -i starling.wasm -o /dev/null
-        DEPENDS starling.wasm
+        COMMAND echo ./null.js | ${WEVAL_BIN} weval --dir . --show-stats --cache starling-ics.wevalcache -w -i starling-raw.wasm -o /dev/null
+        DEPENDS starling-raw.wasm
         VERBATIM
     )
     set(WEVAL_CACHE_FILE "starling-ics.wevalcache")
@@ -110,7 +110,7 @@ else()
     set(AOT 0)
 endif()
 
-set(RUNTIME_FILE "starling.wasm")
+set(RUNTIME_FILE "starling-raw.wasm")
 set(ADAPTER_FILE "preview1-adapter.wasm")
 configure_file("componentize.sh" "${CMAKE_CURRENT_BINARY_DIR}/componentize.sh" @ONLY)
 configure_file(${ADAPTER} "${CMAKE_CURRENT_BINARY_DIR}/${ADAPTER_FILE}" COPYONLY)
@@ -123,19 +123,19 @@ function(componentize OUTPUT)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     list(TRANSFORM ARG_SOURCES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
     list(JOIN ARG_SOURCES " " SOURCES)
-    get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)
+    get_target_property(RUNTIME_DIR starling-raw.wasm BINARY_DIR)
 
     add_custom_command(
             OUTPUT ${OUTPUT}.wasm
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMAND ${CMAKE_COMMAND} ${RUNTIME_DIR}/componentize.sh ${SOURCES} -o ${OUTPUT}.wasm
-            DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling.wasm
+            COMMAND ${RUNTIME_DIR}/componentize.sh ${SOURCES} -o ${OUTPUT}.wasm
+            DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling-raw.wasm
             VERBATIM
     )
     add_custom_target(${OUTPUT} DEPENDS ${OUTPUT}.wasm)
 endfunction()
 
 componentize(smoke-test SOURCES tests/cases/smoke/smoke.js)
-componentize(runtime-eval)
+componentize(starling)
 
 include("tests/tests.cmake")

--- a/cmake/add_as_subproject.cmake
+++ b/cmake/add_as_subproject.cmake
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
 
-add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/.." ${CMAKE_BINARY_DIR}/starling.wasm)
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/.." ${CMAKE_BINARY_DIR}/starling-raw.wasm)
 
 set(PATH_BACKUP CMAKE_MODULE_PATH)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/componentize.sh
+++ b/componentize.sh
@@ -93,15 +93,15 @@ if [[ -n "$IN_FILE" ]]; then
            --cache-ro "$(dirname "$0")/starling-ics.wevalcache" \
            $WEVAL_VERBOSE \
            -o "$OUT_FILE" \
-           -i "$(dirname "$0")/starling.wasm"
+           -i "$(dirname "$0")/starling-raw.wasm"
   else
       echo "$STARLING_ARGS" | WASMTIME_BACKTRACE_DETAILS=1 $wizer --allow-wasi --wasm-bulk-memory true \
            --inherit-stdio true --inherit-env true $preopen_dir -o "$OUT_FILE" \
-           -- "$(dirname "$0")/starling.wasm"
+           -- "$(dirname "$0")/starling-raw.wasm"
   fi
 else
   echo "Creating runtime-eval component $OUT_FILE"
-  cp "$(dirname "$0")/starling.wasm" "$OUT_FILE"
+  cp "$(dirname "$0")/starling-raw.wasm" "$OUT_FILE"
 fi
 
 $wasm_tools component new -v --adapt "wasi_snapshot_preview1=$(dirname "$0")/preview1-adapter.wasm" --output "$OUT_FILE" "$OUT_FILE"

--- a/include/config-parser.h
+++ b/include/config-parser.h
@@ -37,7 +37,7 @@ public:
    * program name, so all the examples for the other `apply_args` overload apply here, too.
    */
   ConfigParser *apply_args(std::string_view args_string) {
-    std::vector<std::string_view> args = { "starling.wasm" };
+    std::vector<std::string_view> args = { "starling-raw.wasm" };
     char last = '\0';
     bool in_quotes = false;
     size_t slice_start = 0;

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -6,7 +6,7 @@ include("wasmtime")
 include("weval")
 
 function(test_e2e TEST_NAME)
-    get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)
+    get_target_property(RUNTIME_DIR starling-raw.wasm BINARY_DIR)
     add_test(e2e-${TEST_NAME} ${BASH_PROGRAM} ${CMAKE_SOURCE_DIR}/tests/test.sh ${RUNTIME_DIR} ${CMAKE_SOURCE_DIR}/tests/e2e/${TEST_NAME})
     set_property(TEST e2e-${TEST_NAME} PROPERTY ENVIRONMENT "WASMTIME=${WASMTIME};WIZER=${WIZER_DIR}/wizer;WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools")
     set_tests_properties(e2e-${TEST_NAME} PROPERTIES TIMEOUT 120)
@@ -15,13 +15,13 @@ endfunction()
 add_custom_target(integration-test-server DEPENDS test-server.wasm)
 
 function(test_integration TEST_NAME)
-    get_target_property(RUNTIME_DIR starling.wasm BINARY_DIR)
+    get_target_property(RUNTIME_DIR starling-raw.wasm BINARY_DIR)
 
     add_custom_command(
         OUTPUT test-server.wasm
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND ${CMAKE_COMMAND} -E env "WASM_TOOLS=${WASM_TOOLS_DIR}/wasm-tools" env "WIZER=${WIZER_DIR}/wizer" env "PREOPEN_DIR=${CMAKE_SOURCE_DIR}/tests" ${RUNTIME_DIR}/componentize.sh ${CMAKE_SOURCE_DIR}/tests/integration/test-server.js test-server.wasm
-        DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling.wasm
+        DEPENDS ${ARG_SOURCES} ${RUNTIME_DIR}/componentize.sh starling-raw.wasm
         VERBATIM
     )
 

--- a/tests/wpt-harness/wpt.cmake
+++ b/tests/wpt-harness/wpt.cmake
@@ -29,7 +29,7 @@ add_custom_command(
         OUTPUT wpt-runtime.wasm
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMAND ${CMAKE_COMMAND} -E env PATH=${WASM_TOOLS_DIR}:${WIZER_DIR}:$ENV{PATH} env "COMPONENTIZE_FLAGS=${COMPONENTIZE_FLAGS}" WPT_ROOT=${WPT_ROOT} ${CMAKE_CURRENT_SOURCE_DIR}/tests/wpt-harness/build-wpt-runtime.sh
-        DEPENDS starling.wasm componentize.sh tests/wpt-harness/build-wpt-runtime.sh tests/wpt-harness/pre-harness.js tests/wpt-harness/post-harness.js
+        DEPENDS starling-raw.wasm componentize.sh tests/wpt-harness/build-wpt-runtime.sh tests/wpt-harness/pre-harness.js tests/wpt-harness/post-harness.js
         VERBATIM
 )
 


### PR DESCRIPTION
This changes the current `starling.wasm` build target to instead be called `starling-raw.wasm` to reflect that it's not yet a usable thing. Additionally, the current `runtime-eval` target is renamed to `starling` and produces a new `starling.wasm` file, which this time is a component that can be used to run dynamically loaded code.

I also updated the documentation accordingly.

And finally, I fixed a bug in `CMakeLists.txt` introduced in #151 that broke the `runtime-eval` build target. That's the entire reason I fell down this rabbit hole 😬