### PR TITLE
fix: ensure filename is defined for builtins in debug builds

### DIFF
--- a/runtime/script_loader.cpp
+++ b/runtime/script_loader.cpp
@@ -203,6 +203,7 @@ static JSObject* get_builtin_module(JSContext* cx, HandleValue id, HandleObject 
   }
 
   JS::CompileOptions opts(cx, *COMPILE_OPTS);
+  opts.setFile("<internal>");
   JS::SourceText<mozilla::Utf8Unit> source;
 
   std::string code = "const { ";


### PR DESCRIPTION
This fixes a bug where `filename` on CompileOptions was not being set for builtin modules in the script loader, which was fine on release builds but failing on debug builds.