### PR TITLE
Fix bugs in handling multiple incoming bodies piped through a `TransFormStream` to an outgoing body

### DIFF
--- a/builtins/web/fetch/fetch_event.cpp
+++ b/builtins/web/fetch/fetch_event.cpp
@@ -85,8 +85,7 @@ bool FetchEvent::init_incoming_request(JSContext *cx, JS::HandleObject self,
   JS::RootedObject request(
       cx, &JS::GetReservedSlot(self, static_cast<uint32_t>(Slots::Request)).toObject());
 
-  MOZ_ASSERT(!Request::request_handle(request));
-
+  MOZ_ASSERT(!RequestOrResponse::maybe_handle(request));
   JS::SetReservedSlot(request, static_cast<uint32_t>(Request::Slots::Request),
                       JS::PrivateValue(req));
 
@@ -175,7 +174,7 @@ bool start_response(JSContext *cx, JS::HandleObject response_obj) {
   host_api::HttpOutgoingResponse* response =
     host_api::HttpOutgoingResponse::make(status, std::move(headers));
 
-  auto existing_handle = Response::response_handle(response_obj);
+  auto existing_handle = Response::maybe_response_handle(response_obj);
   if (existing_handle) {
     MOZ_ASSERT(existing_handle->is_incoming());
   } else {

--- a/builtins/web/fetch/request-response.h
+++ b/builtins/web/fetch/request-response.h
@@ -32,7 +32,8 @@ public:
   static bool is_instance(JSObject *obj);
   static bool is_incoming(JSObject *obj);
   static host_api::HttpRequestResponseBase *handle(JSObject *obj);
-  static host_api::HttpHeadersReadOnly *headers_handle(JSObject *obj);
+  static host_api::HttpRequestResponseBase *maybe_handle(JSObject *obj);
+  static host_api::HttpHeadersReadOnly *maybe_headers_handle(JSObject *obj);
   static bool has_body(JSObject *obj);
   static host_api::HttpIncomingBody *incoming_body_handle(JSObject *obj);
   static host_api::HttpOutgoingBody *outgoing_body_handle(JSObject *obj);
@@ -142,9 +143,6 @@ public:
 
   static JSObject *response_promise(JSObject *obj);
   static JSString *method(JS::HandleObject obj);
-  static host_api::HttpRequest *request_handle(JSObject *obj);
-  static host_api::HttpOutgoingRequest *outgoing_handle(JSObject *obj);
-  static host_api::HttpIncomingRequest *incoming_handle(JSObject *obj);
 
   static const JSFunctionSpec static_methods[];
   static const JSPropertySpec static_properties[];
@@ -209,7 +207,7 @@ public:
   static JSObject *init_slots(HandleObject response);
   static JSObject *create_incoming(JSContext *cx, host_api::HttpIncomingResponse *response);
 
-  static host_api::HttpResponse *response_handle(JSObject *obj);
+  static host_api::HttpResponse *maybe_response_handle(JSObject *obj);
   static uint16_t status(JSObject *obj);
   static JSString *status_message(JSObject *obj);
   static void set_status_message_from_code(JSContext *cx, JSObject *obj, uint16_t code);

--- a/builtins/web/fetch/request-response.h
+++ b/builtins/web/fetch/request-response.h
@@ -67,7 +67,8 @@ public:
    */
   static JSObject *headers(JSContext *cx, JS::HandleObject obj);
 
-  static bool append_body(JSContext *cx, JS::HandleObject self, JS::HandleObject source);
+  static bool append_body(JSContext *cx, JS::HandleObject self, JS::HandleObject source,
+                          api::TaskCompletionCallback callback, HandleObject callback_receiver);
 
   using ParseBodyCB = bool(JSContext *cx, JS::HandleObject self, JS::UniqueChars buf, size_t len);
 

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -638,13 +638,8 @@ public:
                           HandleObject callback_receiver)
       : incoming_body_(incoming_body), outgoing_body_(outgoing_body), cb_(completion_callback),
         cb_receiver_(callback_receiver), state_(State::BlockedOnBoth) {
-    auto res = incoming_body_->subscribe();
-    MOZ_ASSERT(!res.is_err());
-    incoming_pollable_ = res.unwrap();
-
-    res = outgoing_body_->subscribe();
-    MOZ_ASSERT(!res.is_err());
-    outgoing_pollable_ = res.unwrap();
+    incoming_pollable_ = incoming_body_->subscribe().unwrap();
+    outgoing_pollable_ = outgoing_body_->subscribe().unwrap();
   }
 
   [[nodiscard]] bool run(api::Engine *engine) override {

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -574,31 +574,69 @@ void HttpOutgoingBody::write(const uint8_t *bytes, size_t len) {
   MOZ_RELEASE_ASSERT(write_to_outgoing_body(borrow, bytes, len));
 }
 
-Result<Void> HttpOutgoingBody::write_all(const uint8_t *bytes, size_t len) {
+class BodyWriteAllTask final : public api::AsyncTask {
+  HttpOutgoingBody *outgoing_body_;
+  PollableHandle outgoing_pollable_;
+
+  api::TaskCompletionCallback cb_;
+  Heap<JSObject *> cb_receiver_;
+  HostBytes bytes_;
+  size_t offset_ = 0;
+
+public:
+  explicit BodyWriteAllTask(HttpOutgoingBody *outgoing_body, HostBytes bytes,
+                          api::TaskCompletionCallback completion_callback,
+                          HandleObject callback_receiver)
+      : outgoing_body_(outgoing_body), cb_(completion_callback),
+        cb_receiver_(callback_receiver), bytes_(std::move(bytes)) {
+    outgoing_pollable_ = outgoing_body_->subscribe().unwrap();
+  }
+
+  [[nodiscard]] bool run(api::Engine *engine) override {
+    auto res = outgoing_body_->capacity();
+    if (res.is_err()) {
+      return false;
+    }
+    uint64_t capacity = res.unwrap();
+    MOZ_ASSERT(capacity >= 0);
+    auto bytes_to_write = std::min(bytes_.len - offset_, static_cast<size_t>(capacity));
+    outgoing_body_->write(bytes_.ptr.get() + offset_, bytes_to_write);
+    offset_ += bytes_to_write;
+    if (offset_ < bytes_.len) {
+      engine->queue_async_task(this);
+    } else {
+      bytes_.ptr.reset();
+      RootedObject receiver(engine->cx(), cb_receiver_);
+      bool result = cb_(engine->cx(), receiver);
+      cb_ = nullptr;
+      cb_receiver_ = nullptr;
+      return result;
+    }
+
+    return true;
+  }
+
+  [[nodiscard]] bool cancel(api::Engine *engine) override {
+    MOZ_ASSERT_UNREACHABLE("BodyWriteAllTask's semantics don't allow for cancellation");
+    return true;
+  }
+
+  [[nodiscard]] int32_t id() override {
+    return outgoing_pollable_;
+  }
+
+  void trace(JSTracer *trc) override {
+    JS::TraceEdge(trc, &cb_receiver_, "BodyWriteAllTask completion callback receiver");
+  }
+};
+
+Result<Void> HttpOutgoingBody::write_all(api::Engine *engine, HostBytes bytes,
+  api::TaskCompletionCallback callback, HandleObject cb_receiver) {
   if (!valid()) {
     // TODO: proper error handling for all 154 error codes.
     return Result<Void>::err(154);
   }
-
-  auto *state = static_cast<OutgoingBodyHandle *>(handle_state_.get());
-  Borrow<OutputStream> borrow(state->stream_handle_);
-
-  while (len > 0) {
-    auto capacity_res = capacity();
-    if (capacity_res.is_err()) {
-      // TODO: proper error handling for all 154 error codes.
-      return Result<Void>::err(154);
-    }
-    auto capacity = capacity_res.unwrap();
-    auto bytes_to_write = std::min(len, static_cast<size_t>(capacity));
-    if (!write_to_outgoing_body(borrow, bytes, len)) {
-      return Result<Void>::err(154);
-    }
-
-    bytes += bytes_to_write;
-    len -= bytes_to_write;
-  }
-
+  engine->queue_async_task(new BodyWriteAllTask(this, std::move(bytes), callback, cb_receiver));
   return {};
 }
 

--- a/include/host_api.h
+++ b/include/host_api.h
@@ -294,7 +294,8 @@ public:
   /// The host doesn't necessarily write all bytes in any particular call to
   /// `write`, so to ensure all bytes are written, we call it in a loop.
   /// TODO: turn into an async task that writes chunks of the passed buffer until done.
-  Result<Void> write_all(const uint8_t *bytes, size_t len);
+  Result<Void> write_all(api::Engine *engine, HostBytes bytes, api::TaskCompletionCallback callback,
+                         HandleObject cb_receiver);
 
   /// Append an HttpIncomingBody to this one.
   Result<Void> append(api::Engine *engine, HttpIncomingBody *other,

--- a/tests/e2e/multi-stream-forwarding/expect_serve_body.txt
+++ b/tests/e2e/multi-stream-forwarding/expect_serve_body.txt
@@ -1,0 +1,1 @@
+This sentence will be streamed in chunks.

--- a/tests/e2e/multi-stream-forwarding/multi-stream-forwarding.js
+++ b/tests/e2e/multi-stream-forwarding/multi-stream-forwarding.js
@@ -1,0 +1,58 @@
+addEventListener('fetch', async (event) => {
+  try {
+    if (!event.request.url.includes('/nested')) {
+      event.respondWith(main(event));
+      return;
+    }
+
+    let encoder = new TextEncoder();
+    let body = new TransformStream({
+      start(controller) {
+      },
+      transform(chunk, controller) {
+        controller.enqueue(encoder.encode(chunk));
+      },
+      flush(controller) {
+      }
+    });
+    let writer = body.writable.getWriter();
+    event.respondWith(new Response(body.readable));
+    let word = new URL(event.request.url).searchParams.get('word');
+    console.log(`streaming word: ${word}`);
+    for (let letter of word) {
+      console.log(`Writing letter ${letter}`);
+      await writer.write(letter);
+    }
+    if (word.endsWith(".")) {
+      await writer.write("\n");
+    }
+    await writer.close();
+  } catch (e) {
+    console.error(e);
+  }
+});
+async function main(event) {
+  let fullBody = "This sentence will be streamed in chunks.";
+  let responses = [];
+  for (let word of fullBody.split(" ").join("+ ").split(" ")) {
+    responses.push((await fetch(`${event.request.url}/nested?word=${word}`)).body);
+  }
+  return new Response(concatStreams(responses));
+}
+
+function concatStreams(streams) {
+  let { readable, writable } = new TransformStream();
+  async function iter() {
+    for (let stream of streams) {
+      try {
+        await stream.pipeTo(writable, {preventClose: true});
+      } catch (e) {
+        console.error(`error during pipeline execution: ${e}`);
+      }
+    }
+    console.log("closing writable");
+    await writable.close();
+  }
+  iter();
+  return readable;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -39,6 +39,7 @@ test_e2e(tla-err)
 test_e2e(tla-runtime-resolve)
 test_e2e(tla)
 test_e2e(stream-forwarding)
+test_e2e(multi-stream-forwarding)
 
 test_integration(btoa)
 test_integration(crypto)

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -38,6 +38,7 @@ test_e2e(syntax-err)
 test_e2e(tla-err)
 test_e2e(tla-runtime-resolve)
 test_e2e(tla)
+test_e2e(stream-forwarding)
 
 test_integration(btoa)
 test_integration(crypto)


### PR DESCRIPTION
This was pretty gnarly to work through, but I think came out reasonably clean. The two key pieces are:
- delaying the first read from an incoming stream that's been piped to a `TransformStream` until the latter is actually read from, and hence doesn't have backpressure applied anymore. This part guarantees that when the read would happen, we have the full pipeline in place and can hand things off to the host API instead of handling anything in the JS `fetch` API implementation.
- properly integrating these two pieces, and only closing the incoming body's `ReadableStream` once the host API reports that it's been dealt with to completion.

This PR additionally contains some fixes to how writes to bodies are handled, and some cleanup. These are both in separate patches which can be reviewed separately, if that seems easier.