### PR TITLE
Add Request and Response blob methods

### DIFF
--- a/builtins/web/blob.cpp
+++ b/builtins/web/blob.cpp
@@ -2,16 +2,18 @@
 #include "builtin.h"
 #include "encode.h"
 #include "extension-api.h"
-#include "mozilla/UniquePtr.h"
 #include "rust-encoding.h"
 #include "streams/native-stream-source.h"
 
+#include "mozilla/UniquePtr.h"
 #include "js/ArrayBuffer.h"
 #include "js/Conversions.h"
 #include "js/experimental/TypedData.h"
+#include "js/HashTable.h"
 #include "js/Stream.h"
 #include "js/TypeDecls.h"
 #include "js/Value.h"
+#include "js/Vector.h"
 
 namespace {
 

--- a/builtins/web/blob.h
+++ b/builtins/web/blob.h
@@ -6,6 +6,7 @@
 #include "js/AllocPolicy.h"
 #include "js/GCHashTable.h"
 #include "js/TypeDecls.h"
+#include "js/Vector.h"
 
 namespace builtins {
 namespace web {
@@ -53,10 +54,9 @@ public:
   enum Slots { Data, Type, Endings, Readers, Count };
   enum LineEndings { Transparent, Native };
 
-  using ByteBuffer = std::vector<uint8_t>;
   using HeapObj = Heap<JSObject *>;
-  using ReadersMap =
-      JS::GCHashMap<HeapObj, BlobReader, js::StableCellHasher<HeapObj>, js::SystemAllocPolicy>;
+  using ByteBuffer = js::Vector<uint8_t, 0, js::SystemAllocPolicy>;
+  using ReadersMap = JS::GCHashMap<HeapObj, BlobReader, js::StableCellHasher<HeapObj>, js::SystemAllocPolicy>;
 
   static ReadersMap *readers(JSObject *self);
   static ByteBuffer *blob(JSObject *self);
@@ -75,7 +75,7 @@ public:
   static JSObject *data_to_owned_array_buffer(JSContext *cx, HandleObject self);
   static JSObject *data_to_owned_array_buffer(JSContext *cx, HandleObject self, size_t offset,
                                               size_t size, size_t *bytes_read);
-  static JSObject *create(JSContext *cx, std::unique_ptr<ByteBuffer> data, HandleString type);
+  static JSObject *create(JSContext *cx, UniqueChars data, size_t data_len, HandleString type);
 
   static bool init_class(JSContext *cx, HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, Value *vp);

--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -549,7 +549,6 @@ bool RequestOrResponse::parse_body(JSContext *cx, JS::HandleObject self, JS::Uni
       return RejectPromiseWithPendingError(cx, result_promise);
     }
 
-    // We can drop `buf` as the data has been now copied over to blob
     result.setObject(*blob);
   } else {
     JS::RootedString text(cx, JS_NewStringCopyUTF8N(cx, JS::UTF8Chars(buf.get(), len)));

--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -542,11 +542,8 @@ bool RequestOrResponse::parse_body(JSContext *cx, JS::HandleObject self, JS::Uni
     static_cast<void>(buf.release());
     result.setObject(*array_buffer);
   } else if constexpr (result_type == RequestOrResponse::BodyReadResult::Blob) {
-    auto bytes = reinterpret_cast<uint8_t *>(buf.get());
-    auto data = std::make_unique<std::vector<uint8_t>>(bytes, bytes + len);
-
     JS::RootedString contentType(cx, JS_GetEmptyString(cx));
-    JS::RootedObject blob(cx, blob::Blob::create(cx, std::move(data), contentType));
+    JS::RootedObject blob(cx, blob::Blob::create(cx, std::move(buf), len, contentType));
 
     if (!blob) {
       return RejectPromiseWithPendingError(cx, result_promise);

--- a/builtins/web/fetch/request-response.h
+++ b/builtins/web/fetch/request-response.h
@@ -74,6 +74,7 @@ public:
 
   enum class BodyReadResult {
     ArrayBuffer,
+    Blob,
     JSON,
     Text,
   };

--- a/builtins/web/structured-clone.cpp
+++ b/builtins/web/structured-clone.cpp
@@ -1,6 +1,8 @@
 #include "structured-clone.h"
+#include "blob.h"
 
 #include "dom-exception.h"
+#include "mozilla/Assertions.h"
 
 namespace builtins {
 namespace web {
@@ -8,29 +10,20 @@ namespace structured_clone {
 
 // Magic number used in structured cloning as a tag to identify a
 // URLSearchParam.
-#define SCTAG_DOM_URLSEARCHPARAMS JS_SCTAG_USER_MIN
+#define SCTAG_DOM_URLSEARCHPARAMS (JS_SCTAG_USER_MIN)
+#define SCTAG_DOM_BLOB            (JS_SCTAG_USER_MIN + 1)
 
 /**
  * Reads non-JS builtins during structured cloning.
  *
- * Currently the only relevant builtin is URLSearchParams, but that'll grow to
- * include Blob and FormData, too.
+ * Currently the only relevant builtin is URLSearchParams and Blob, but that'll grow to
+ * include FormData, too.
  *
  * TODO: Add support for CryptoKeys
  */
 JSObject *ReadStructuredClone(JSContext *cx, JSStructuredCloneReader *r,
                               const JS::CloneDataPolicy &cloneDataPolicy, uint32_t tag,
                               uint32_t len, void *closure) {
-  MOZ_ASSERT(tag == SCTAG_DOM_URLSEARCHPARAMS);
-
-  RootedObject urlSearchParamsInstance(cx,
-                                       JS_NewObjectWithGivenProto(cx, &url::URLSearchParams::class_,
-                                                                  url::URLSearchParams::proto_obj));
-  RootedObject params_obj(cx, url::URLSearchParams::create(cx, urlSearchParamsInstance));
-  if (!params_obj) {
-    return nullptr;
-  }
-
   void *bytes = JS_malloc(cx, len);
   if (!bytes) {
     JS_ReportOutOfMemory(cx);
@@ -41,30 +34,60 @@ JSObject *ReadStructuredClone(JSContext *cx, JSStructuredCloneReader *r,
     return nullptr;
   }
 
-  jsurl::SpecString init((uint8_t *)bytes, len, len);
-  jsurl::params_init(url::URLSearchParams::get_params(params_obj), &init);
+  switch (tag) {
+  case SCTAG_DOM_URLSEARCHPARAMS: {
+    RootedObject urlSearchParamsInstance(cx,
+                                         JS_NewObjectWithGivenProto(cx, &url::URLSearchParams::class_,
+                                                                    url::URLSearchParams::proto_obj));
+    RootedObject params_obj(cx, url::URLSearchParams::create(cx, urlSearchParamsInstance));
+    if (!params_obj) {
+      return nullptr;
+    }
 
-  return params_obj;
+    jsurl::SpecString init((uint8_t *)bytes, len, len);
+    jsurl::params_init(url::URLSearchParams::get_params(params_obj), &init);
+
+    return params_obj;
+
+  }
+  case SCTAG_DOM_BLOB: {
+    JS::RootedString contentType(cx, JS_GetEmptyString(cx));
+    UniqueChars chars(reinterpret_cast<char *>(bytes));
+
+    RootedObject blob(cx, blob::Blob::create(cx, std::move(chars), len, contentType));
+    return blob;
+  }
+  default: {
+    MOZ_ASSERT_UNREACHABLE("structured-clone undefined tag");
+    return nullptr;
+  }
+  }
 }
 
 /**
  * Writes non-JS builtins during structured cloning.
  *
- * Currently the only relevant builtin is URLSearchParams, but that'll grow to
- * include Blob and FormData, too.
+ * Currently the only relevant builtin is URLSearchParams and Blob, but that'll grow to
+ * include FormData, too.
  *
  * TODO: Add support for CryptoKeys
  */
 bool WriteStructuredClone(JSContext *cx, JSStructuredCloneWriter *w, JS::HandleObject obj,
                           bool *sameProcessScopeRequired, void *closure) {
-  if (!url::URLSearchParams::is_instance(obj)) {
+  if (url::URLSearchParams::is_instance(obj)) {
+    auto slice = url::URLSearchParams::serialize(cx, obj);
+    if (!JS_WriteUint32Pair(w, SCTAG_DOM_URLSEARCHPARAMS, slice.len) ||
+        !JS_WriteBytes(w, (void *)slice.data, slice.len)) {
+      return false;
+    }
+  } else if (blob::Blob::is_instance(obj)) {
+    auto data = blob::Blob::blob(obj);
+    if (!JS_WriteUint32Pair(w, SCTAG_DOM_BLOB, data->length()) ||
+        !JS_WriteBytes(w, (void *)data->begin(), data->length())) {
+      return false;
+    }
+  } else {
     return dom_exception::DOMException::raise(cx, "The object could not be cloned", "DataCloneError");
-  }
-
-  auto slice = url::URLSearchParams::serialize(cx, obj);
-  if (!JS_WriteUint32Pair(w, SCTAG_DOM_URLSEARCHPARAMS, slice.len) ||
-      !JS_WriteBytes(w, (void *)slice.data, slice.len)) {
-    return false;
   }
 
   return true;

--- a/tests/wpt-harness/expectations/fetch/api/body/cloned-any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/body/cloned-any.js.json
@@ -12,6 +12,6 @@
     "status": "PASS"
   },
   "Blob is cloned": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/fetch/api/request/request-consume-empty.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-consume-empty.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "Consume request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume request's body as arrayBuffer": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-consume-empty.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-consume-empty.any.js.json
@@ -21,13 +21,13 @@
     "status": "FAIL"
   },
   "Consume empty blob request body as arrayBuffer": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text request body as arrayBuffer": {
     "status": "PASS"
   },
   "Consume empty blob request body as text": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text request body as text": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-consume.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-consume.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "Consume String request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume String request's body as arrayBuffer": {
     "status": "PASS"
@@ -18,7 +18,7 @@
     "status": "PASS"
   },
   "Consume ArrayBuffer request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume ArrayBuffer request's body as arrayBuffer": {
     "status": "PASS"
@@ -33,7 +33,7 @@
     "status": "PASS"
   },
   "Consume Uint8Array request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume Uint8Array request's body as arrayBuffer": {
     "status": "PASS"
@@ -48,7 +48,7 @@
     "status": "PASS"
   },
   "Consume Int8Array request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume Int8Array request's body as arrayBuffer": {
     "status": "PASS"
@@ -63,7 +63,7 @@
     "status": "PASS"
   },
   "Consume Float32Array request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume Float32Array request's body as arrayBuffer": {
     "status": "PASS"
@@ -78,7 +78,7 @@
     "status": "PASS"
   },
   "Consume DataView request's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume DataView request's body as arrayBuffer": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-consume.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-consume.any.js.json
@@ -93,22 +93,22 @@
     "status": "FAIL"
   },
   "Consume blob response's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as text": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as json": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as arrayBuffer": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume blob response's body as bytes": {
     "status": "FAIL"
   },
   "Consume blob response's body as blob (empty blob as input)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume JSON from text: '\"null\"'": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-disturbed.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-disturbed.any.js.json
@@ -1,0 +1,29 @@
+{
+  "Request's body: initial state": {
+    "status": "PASS"
+  },
+  "Request without body cannot be disturbed": {
+    "status": "PASS"
+  },
+  "Check cloning a disturbed request": {
+    "status": "FAIL"
+  },
+  "Check creating a new request from a disturbed request": {
+    "status": "PASS"
+  },
+  "Check creating a new request with a new body from a disturbed request": {
+    "status": "PASS"
+  },
+  "Input request used for creating new request became disturbed": {
+    "status": "FAIL"
+  },
+  "Input request used for creating new request became disturbed even if body is not used": {
+    "status": "FAIL"
+  },
+  "Check consuming a disturbed request": {
+    "status": "PASS"
+  },
+  "Request construction failure should not set \"bodyUsed\"": {
+    "status": "FAIL"
+  }
+}

--- a/tests/wpt-harness/expectations/fetch/api/request/request-headers.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-headers.any.js.json
@@ -177,7 +177,7 @@
     "status": "PASS"
   },
   "Testing empty Request Content-Type header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Test that Request.headers has the [SameObject] extended attribute": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-init-contenttype.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-init-contenttype.any.js.json
@@ -3,13 +3,13 @@
     "status": "PASS"
   },
   "Default Content-Type for Request with Blob body (no type set)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Request with Blob body (empty type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Request with Blob body (set type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Request with buffer source body": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-structure.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-structure.any.js.json
@@ -6,7 +6,7 @@
     "status": "PASS"
   },
   "Request has blob method": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Request has formData method": {
     "status": "FAIL"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-consume-empty.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-consume-empty.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "Consume response's body as blob": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume response's body as arrayBuffer": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-consume-empty.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-consume-empty.any.js.json
@@ -21,13 +21,13 @@
     "status": "FAIL"
   },
   "Consume empty blob response body as arrayBuffer": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text response body as arrayBuffer": {
     "status": "PASS"
   },
   "Consume empty blob response body as text": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Consume empty text response body as text": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-error-from-stream.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-error-from-stream.any.js.json
@@ -9,7 +9,7 @@
     "status": "PASS"
   },
   "ReadableStream start() Error propagates to Response.blob() Promise": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "ReadableStream start() Error propagates to Response.bytes() Promise": {
     "status": "FAIL"
@@ -27,7 +27,7 @@
     "status": "PASS"
   },
   "ReadableStream pull() Error propagates to Response.blob() Promise": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "ReadableStream pull() Error propagates to Response.bytes() Promise": {
     "status": "FAIL"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-init-contenttype.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-init-contenttype.any.js.json
@@ -3,13 +3,13 @@
     "status": "PASS"
   },
   "Default Content-Type for Response with Blob body (no type set)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Response with Blob body (empty type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Response with Blob body (set type)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Default Content-Type for Response with buffer source body": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-bad-chunk.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-bad-chunk.any.js.json
@@ -3,7 +3,7 @@
     "status": "PASS"
   },
   "ReadableStream with non-Uint8Array chunk passed to Response.blob() causes TypeError": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "ReadableStream with non-Uint8Array chunk passed to Response.bytes() causes TypeError": {
     "status": "FAIL"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-1.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-1.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after getting the Response body - not disturbed, not locked (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting the Response body - not disturbed, not locked (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after getting the Response body - not disturbed, not locked (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting the Response body - not disturbed, not locked (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after getting the Response body - not disturbed, not locked (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting the Response body - not disturbed, not locked (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-2.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-2.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after getting a locked Response body (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting a locked Response body (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after getting a locked Response body (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting a locked Response body (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after getting a locked Response body (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after getting a locked Response body (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-3.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-3.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after reading the Response body (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after reading the Response body (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after reading the Response body (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after reading the Response body (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after reading the Response body (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after reading the Response body (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-4.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/response/response-stream-disturbed-4.any.js.json
@@ -1,6 +1,6 @@
 {
   "Getting blob after cancelling the Response body (body source: fetch)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after cancelling the Response body (body source: fetch)": {
     "status": "PASS"
@@ -12,7 +12,7 @@
     "status": "PASS"
   },
   "Getting blob after cancelling the Response body (body source: stream)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after cancelling the Response body (body source: stream)": {
     "status": "PASS"
@@ -24,7 +24,7 @@
     "status": "PASS"
   },
   "Getting blob after cancelling the Response body (body source: string)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Getting text after cancelling the Response body (body source: string)": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/html/webappapis/structured-clone/structured-clone.any.js.json
+++ b/tests/wpt-harness/expectations/html/webappapis/structured-clone/structured-clone.any.js.json
@@ -246,37 +246,37 @@
     "status": "FAIL"
   },
   "Blob unpaired high surrogate (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Blob unpaired low surrogate (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Blob paired surrogates (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Blob empty": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Blob NUL": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Array Blob object, Blob basic": {
     "status": "FAIL"
   },
   "Array Blob object, Blob unpaired high surrogate (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Array Blob object, Blob unpaired low surrogate (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Array Blob object, Blob paired surrogates (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Array Blob object, Blob empty": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Array Blob object, Blob NUL": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Array Blob object, two Blobs": {
     "status": "FAIL"
@@ -285,19 +285,19 @@
     "status": "FAIL"
   },
   "Object Blob object, Blob unpaired high surrogate (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Object Blob object, Blob unpaired low surrogate (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Object Blob object, Blob paired surrogates (invalid utf-8)": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Object Blob object, Blob empty": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Object Blob object, Blob NUL": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "File basic": {
     "status": "FAIL"
@@ -345,7 +345,7 @@
     "status": "PASS"
   },
   "An object whose interface is deleted from the global must still deserialize": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "A subclass instance will deserialize as its closest serializable superclass": {
     "status": "FAIL"


### PR DESCRIPTION
This patch adds `blob` API to `Request` and `Response` methods.

The patch also refactors the internal blob storage, changing it from `std::vector` to `mozilla::Vector`. This optimization allows the `Blob` to be created without copying data by transferring buffer ownership, as is the case for both `Response` and `Request` objects.

Closes: https://github.com/bytecodealliance/StarlingMonkey/issues/121
