### PR TITLE
fix: remove invalid event loop interest bump

### DIFF
--- a/builtins/web/blob.cpp
+++ b/builtins/web/blob.cpp
@@ -184,7 +184,6 @@ class StreamTask final : public api::AsyncTask {
 
 public:
   explicit StreamTask(const HandleObject source, api::Engine *engine) : source_(source) {
-    engine->incr_event_loop_interest();
     handle_ = IMMEDIATE_TASK_HANDLE;
   }
 
@@ -234,7 +233,6 @@ public:
 
   [[nodiscard]] bool cancel(api::Engine *engine) override {
     handle_ = INVALID_POLLABLE_HANDLE;
-    engine->decr_event_loop_interest();
     return true;
   }
 


### PR DESCRIPTION
There are two problems with this event loop interest management for the new blob StreamTask implementation:

1. I'm not seeing where non-cancelled stream tasks are getting their interest decremented
2. Event loop interest is purely about the request / response lifecycle requirements and not arbitrary immediate tracking

//cc @andreiltd 