### PR TITLE
Implement `URL.createObjectURL` and `URL.revokeObjectURL` methods

### DIFF
--- a/builtins/web/crypto/crypto-algorithm.cpp
+++ b/builtins/web/crypto/crypto-algorithm.cpp
@@ -1841,6 +1841,7 @@ JSObject *CryptoAlgorithmRSASSA_PKCS1_v1_5_Import::importKey(JSContext *cx, Cryp
   case CryptoKeyFormat::Spki:
   case CryptoKeyFormat::Pkcs8: {
     // TODO: Add implementations for these
+    [[fallthrough]];
   }
   default: {
     DOMException::raise(cx, "Supplied format is not supported", "DataError");

--- a/builtins/web/crypto/crypto.cpp
+++ b/builtins/web/crypto/crypto.cpp
@@ -1,14 +1,8 @@
-// TODO: remove these once the warnings are fixed
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
-#pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
-#include "js/experimental/TypedData.h" // used in "js/Conversions.h"
-#pragma clang diagnostic pop
-
 #include "../dom-exception.h"
 #include "crypto.h"
 #include "host_api.h"
 #include "subtle-crypto.h"
+#include "uuid.h"
 
 bool is_int_typed_array(JSObject *obj) {
   return JS_IsInt8Array(obj) || JS_IsUint8Array(obj) || JS_IsInt16Array(obj) ||
@@ -66,114 +60,18 @@ bool Crypto::get_random_values(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
-/*
-  FROM RFC 4122
-  The formal definition of the UUID string representation is
-  provided by the following ABNF [7]:
-
-  UUID                   = time-low "-" time-mid "-"
-                            time-high-and-version "-"
-                            clock-seq-and-reserved
-                            clock-seq-low "-" node
-  time-low               = 4hexOctet
-  time-mid               = 2hexOctet
-  time-high-and-version  = 2hexOctet
-  clock-seq-and-reserved = hexOctet
-  clock-seq-low          = hexOctet
-  node                   = 6hexOctet
-  hexOctet               = hexDigit hexDigit
-  hexDigit =
-        "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" /
-        "a" / "b" / "c" / "d" / "e" / "f" /
-        "A" / "B" / "C" / "D" / "E" / "F"
-*/
-struct UUID {
-  uint32_t time_low;
-  uint16_t time_mid;
-  uint16_t time_high_and_version;
-  uint8_t clock_seq_and_reserved;
-  uint8_t clock_seq_low;
-  uint8_t node[6];
-};
-
-/*
-  FROM RFC 4122
-  4.1.3.  Version
-
-  The version number is in the most significant 4 bits of the time
-  stamp (bits 4 through 7 of the time_hi_and_version field).
-
-  The following table lists the currently-defined versions for this
-  UUID variant.
-
-  Msb0  Msb1  Msb2  Msb3   Version  Description
-
-    0     0     0     1        1    The time-based version
-                                    specified in this document.
-
-    0     0     1     0        2    DCE Security version, with
-                                    embedded POSIX UIDs.
-
-    0     0     1     1        3    The name-based version
-                                    specified in this document
-                                    that uses MD5 hashing.
-
-    0     1     0     0        4    The randomly or pseudo-
-                                    randomly generated version
-                                    specified in this document.
-
-    0     1     0     1        5    The name-based version
-                                    specified in this document
-                                    that uses SHA-1 hashing.
-*/
-/*
-  FROM RFC 4122
-  The version 4 UUID is meant for generating UUIDs from truly-random or
-  pseudo-random numbers.
-
-  The algorithm is as follows:
-
-  Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one,
-  respectively.
-
-  Set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the
-  4-bit version number from Section 4.1.3.
-
-  Set all the other bits to randomly (or pseudo-randomly) chosen values.
-*/
 bool Crypto::random_uuid(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0)
-  UUID id;
 
-  {
-    auto res = host_api::Random::get_bytes(sizeof(id));
-    if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
-      return false;
-    }
-
-    auto bytes = std::move(res.unwrap());
-    std::copy_n(bytes.begin(), sizeof(id), reinterpret_cast<uint8_t *>(&id));
+  auto maybe_uuid = random_uuid_v4(cx);
+  if (!maybe_uuid.has_value()) {
+    return false;
   }
 
-  // Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and
-  // one, respectively.
-  id.clock_seq_and_reserved &= 0x3f;
-  id.clock_seq_and_reserved |= 0x80;
-  // Set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the
-  // 4-bit version number from Section 4.1.3.
-  id.time_high_and_version &= 0x0fff;
-  id.time_high_and_version |= 0x4000;
+  auto uuid = maybe_uuid.value();
+  MOZ_ASSERT(uuid.size() == 36);
 
-  const char *fmt = "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x";
-  char buf[80];
-  std::snprintf(buf, sizeof(buf) - 1, fmt, id.time_low, (uint32_t)id.time_mid,
-                (uint32_t)id.time_high_and_version, (uint32_t)id.clock_seq_and_reserved,
-                (uint32_t)id.clock_seq_low, (uint32_t)id.node[0], (uint32_t)id.node[1],
-                (uint32_t)id.node[2], (uint32_t)id.node[3], (uint32_t)id.node[4],
-                (uint32_t)id.node[5]);
-  JS::RootedString str(cx, JS_NewStringCopyN(cx, buf, 36));
-
+  JS::RootedString str(cx, JS_NewStringCopyN(cx, uuid.data(), uuid.size()));
   if (!str) {
     return false;
   }

--- a/builtins/web/crypto/uuid.cpp
+++ b/builtins/web/crypto/uuid.cpp
@@ -1,0 +1,100 @@
+#include "uuid.h"
+#include "host_api.h"
+
+#include <fmt/core.h>
+
+namespace builtins {
+namespace web {
+namespace crypto {
+
+// FROM RFC 4122
+// The formal definition of the UUID string representation is
+// provided by the following ABNF [7]:
+//
+// UUID                   = time-low "-" time-mid "-"
+//                           time-high-and-version "-"
+//                           clock-seq-and-reserved
+//                           clock-seq-low "-" node
+// time-low               = 4hexOctet
+// time-mid               = 2hexOctet
+// time-high-and-version  = 2hexOctet
+// clock-seq-and-reserved = hexOctet
+// clock-seq-low          = hexOctet
+// node                   = 6hexOctet
+// hexOctet               = hexDigit hexDigit
+// hexDigit =
+//       "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" /
+//       "a" / "b" / "c" / "d" / "e" / "f" /
+//       "A" / "B" / "C" / "D" / "E" / "F"
+struct UUID {
+  uint32_t time_low;
+  uint16_t time_mid;
+  uint16_t time_high_and_version;
+  uint8_t clock_seq_and_reserved;
+  uint8_t clock_seq_low;
+  uint8_t node[6];
+};
+
+// FROM RFC 4122
+// 4.1.3.  Version
+//
+// The version number is in the most significant 4 bits of the time
+// stamp (bits 4 through 7 of the time_hi_and_version field).
+//
+// The following table lists the currently-defined versions for this
+// UUID variant.
+//
+// Msb0  Msb1  Msb2  Msb3   Version  Description
+//
+//   0     0     0     1        1    The time-based version
+//                                   specified in this document.
+//
+//   0     0     1     0        2    DCE Security version, with
+//                                   embedded POSIX UIDs.
+//
+//   0     0     1     1        3    The name-based version
+//                                   specified in this document
+//                                   that uses MD5 hashing.
+//
+//   0     1     0     0        4    The randomly or pseudo-
+//                                   randomly generated version
+//                                   specified in this document.
+//
+//   0     1     0     1        5    The name-based version
+//                                   specified in this document
+//                                   that uses SHA-1 hashing.
+std::optional<std::string> random_uuid_v4(JSContext *cx) {
+  UUID id;
+
+  {
+    auto res = host_api::Random::get_bytes(sizeof(id));
+    if (auto *err = res.to_err()) {
+      HANDLE_ERROR(cx, *err);
+      return std::nullopt;
+    }
+
+    auto bytes = std::move(res.unwrap());
+    std::copy_n(bytes.begin(), sizeof(id), reinterpret_cast<uint8_t *>(&id));
+  }
+
+  // Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and
+  // one, respectively.
+  id.clock_seq_and_reserved &= 0x3f;
+  id.clock_seq_and_reserved |= 0x80;
+  // Set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the
+  // 4-bit version number from Section 4.1.3.
+  id.time_high_and_version &= 0x0fff;
+  id.time_high_and_version |= 0x4000;
+
+  return fmt::format("{:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+                      id.time_low,
+                      id.time_mid,
+                      id.time_high_and_version,
+                      id.clock_seq_and_reserved, id.clock_seq_low,
+                      id.node[0], id.node[1], id.node[2],
+                      id.node[3], id.node[4], id.node[5]);
+}
+
+} // namespace uuid
+} // namespace web
+} // namespace builtins

--- a/builtins/web/crypto/uuid.h
+++ b/builtins/web/crypto/uuid.h
@@ -1,0 +1,29 @@
+#ifndef BUILTINS_WEB_CRYPTO_UUID_H
+#define BUILTINS_WEB_CRYPTO_UUID_H
+
+#include "builtin.h"
+
+namespace builtins {
+namespace web {
+namespace crypto {
+
+// FROM RFC 4122
+// The version 4 UUID is meant for generating UUIDs from truly-random or
+// pseudo-random numbers.
+//
+// The algorithm is as follows:
+//
+// Set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one,
+// respectively.
+//
+// Set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the
+// 4-bit version number from Section 4.1.3.
+//
+// Set all the other bits to randomly (or pseudo-randomly) chosen values.
+std::optional<std::string> random_uuid_v4(JSContext *cx);
+
+} // namespace crypto
+} // namespace web
+} // namespace builtins
+
+#endif // BUILTINS_WEB_CRYPTO_UUID_H

--- a/builtins/web/fetch/fetch-api.cpp
+++ b/builtins/web/fetch/fetch-api.cpp
@@ -1,7 +1,7 @@
 #include "fetch-api.h"
+#include "fetch-utils.h"
 #include "builtin.h"
 #include "encode.h"
-#include "event_loop.h"
 #include "extension-api.h"
 #include "headers.h"
 #include "mozilla/Assertions.h"
@@ -10,17 +10,13 @@
 #include "../blob.h"
 #include "../url.h"
 
-#include "js/String.h"
-#include <charconv>
 #include <fmt/format.h>
-#include <memory>
 
 namespace builtins::web::fetch {
 
 using blob::Blob;
 using fetch::Headers;
 using host_api::HostString;
-using url::URL;
 
 static api::Engine *ENGINE;
 
@@ -131,7 +127,7 @@ bool fetch_blob(JSContext *cx, HandleObject request_obj, HostString method, Host
   // 7. Let blob be the result of obtaining a blob object given blobURLEntry and
   // navigationOrEnvironment.
   std::string url_key(url.ptr.get());
-  RootedObject blob(cx, URL::getObjectURL(url_key));
+  RootedObject blob(cx, url::URL::getObjectURL(url_key));
 
   // 8. If blob is not a Blob object, then return a network error.
   if (!blob || !Blob::is_instance(blob)) {
@@ -181,58 +177,16 @@ bool fetch_blob(JSContext *cx, HandleObject request_obj, HostString method, Host
     auto *headers = Headers::get_index(cx, req_headers, maybe_range_index.value());
     MOZ_ASSERT(headers);
 
-    auto &[key, val] = *headers;
-    std::string_view range_value(val);
+    const auto &[key, val] = *headers;
+    std::string_view range_query(val);
 
-    if (!range_value.starts_with("bytes=")) {
+    // 5 and 6 see extract_range function
+    auto maybe_range = extract_range(range_query, full_len);
+    if (!maybe_range.has_value()) {
       return api::throw_error(cx, FetchErrors::FetchNetworkError);
     }
 
-    range_value.remove_prefix(6); // bytes=
-    auto dash_pos = range_value.find('-');
-
-    if (dash_pos == std::string_view::npos) {
-      return api::throw_error(cx, FetchErrors::FetchNetworkError);
-    }
-
-    auto start_str = range_value.substr(0, dash_pos);
-    auto end_str = range_value.substr(dash_pos + 1);
-
-    auto to_size = [](std::string_view s) -> std::optional<size_t> {
-      size_t v;
-      auto [ptr, ec] = std::from_chars(s.begin(), s.end(), v);
-      return ec == std::errc() ? std::optional<size_t>(v) : std::nullopt;
-    };
-
-    //   5. Let (rangeStart, rangeEnd) be rangeValue.
-    auto maybe_start_range = to_size(start_str);
-    auto maybe_end_range = to_size(end_str);
-
-    size_t start_range = 0;
-    size_t end_range = 0;
-
-    // 6. If rangeStart is null:
-    if (!maybe_start_range.has_value()) {
-      // If both start_range and end_range are not provided, it's an error.
-      if (!maybe_end_range.has_value()) {
-        return api::throw_error(cx, FetchErrors::FetchNetworkError);
-      }
-
-      // 1. Set rangeStart to fullLength - rangeEnd.
-      // 2. Set rangeEnd to rangeStart + rangeEnd - 1.
-      start_range = full_len - maybe_end_range.value();
-      end_range = start_range + maybe_end_range.value() - 1;
-      // 7. Otherwise:
-    } else {
-      // 1. If rangeStart is greater than or equal to fullLength, then return a network error.
-      if (maybe_start_range.value() > full_len) {
-        return api::throw_error(cx, FetchErrors::FetchNetworkError);
-      }
-      // 2. If rangeEnd is null or rangeEnd is greater than or equal to fullLength, then set
-      // rangeEnd to fullLength - 1.
-      start_range = maybe_start_range.value();
-      end_range = std::min(maybe_end_range.value_or(full_len - 1), full_len - 1);
-    }
+    const auto [start_range, end_range] = maybe_range.value();
 
     // 8. Let slicedBlob be the result of invoking slice blob given blob, rangeStart, rangeEnd + 1, and type.
     // 9. Let slicedBodyWithType be the result of safely extracting slicedBlob.

--- a/builtins/web/fetch/fetch-api.cpp
+++ b/builtins/web/fetch/fetch-api.cpp
@@ -1,17 +1,314 @@
 #include "fetch-api.h"
+#include "builtin.h"
+#include "encode.h"
 #include "event_loop.h"
+#include "extension-api.h"
 #include "headers.h"
+#include "mozilla/Assertions.h"
 #include "request-response.h"
 
-#include <encode.h>
+#include "../blob.h"
+#include "../url.h"
 
+#include "js/String.h"
+#include <charconv>
+#include <fmt/format.h>
 #include <memory>
-
-using builtins::web::fetch::Headers;
 
 namespace builtins::web::fetch {
 
+using blob::Blob;
+using fetch::Headers;
+using host_api::HostString;
+using url::URL;
+
 static api::Engine *ENGINE;
+
+enum class FetchScheme {
+  About,
+  Blob,
+  Data,
+  File,
+  Http,
+  Https,
+};
+
+std::optional<FetchScheme> scheme_from_url(const std::string_view &url) {
+  if (url.starts_with("about:")) {
+    return FetchScheme::About;
+  } else if (url.starts_with("blob:")) {
+    return FetchScheme::Blob;
+  } else if (url.starts_with("data:")) {
+    return FetchScheme::Data;
+  } else if (url.starts_with("file:")) {
+    return FetchScheme::File;
+  } else if (url.starts_with("http")) {
+    return FetchScheme::Http;
+  } else if (url.starts_with("https")) {
+    return FetchScheme::Https;
+  } else {
+    return std::nullopt;
+  }
+}
+
+bool fetch_https(JSContext *cx, HandleObject request_obj, HostString method, HostString url,
+                 MutableHandleValue rval) {
+  unique_ptr<host_api::HttpHeaders> headers =
+      RequestOrResponse::headers_handle_clone(cx, request_obj);
+  if (!headers) {
+    return false;
+  }
+
+  auto request = host_api::HttpOutgoingRequest::make(method, std::move(url), std::move(headers));
+  MOZ_RELEASE_ASSERT(request);
+  JS_SetReservedSlot(request_obj, static_cast<uint32_t>(Request::Slots::Request),
+                     PrivateValue(request));
+
+  RootedObject response_promise(cx, JS::NewPromiseObject(cx, nullptr));
+  if (!response_promise)
+    return false;
+
+  bool streaming = false;
+  if (!RequestOrResponse::maybe_stream_body(cx, request_obj, request, &streaming)) {
+    return false;
+  }
+  if (streaming) {
+    // Ensure that the body handle is stored before making the request handle invalid by sending it.
+    request->body();
+  }
+
+  host_api::FutureHttpIncomingResponse *pending_handle;
+  {
+    auto res = request->send();
+    if (auto *err = res.to_err()) {
+      HANDLE_ERROR(cx, *err);
+      return false;
+    }
+
+    pending_handle = res.unwrap();
+  }
+
+  // If the request body is streamed, we need to wait for streaming to complete
+  // before marking the request as pending.
+  if (!streaming) {
+    ENGINE->queue_async_task(new ResponseFutureTask(request_obj, pending_handle));
+  }
+
+  SetReservedSlot(request_obj, static_cast<uint32_t>(Request::Slots::ResponsePromise),
+                  ObjectValue(*response_promise));
+  SetReservedSlot(request_obj, static_cast<uint32_t>(Request::Slots::PendingResponseHandle),
+                  PrivateValue(pending_handle));
+
+  rval.setObject(*response_promise);
+  return true;
+}
+
+/// https://fetch.spec.whatwg.org/#scheme-fetch
+bool fetch_blob(JSContext *cx, HandleObject request_obj, HostString method, HostString url,
+                MutableHandleValue rval) {
+
+  RootedObject response_promise(cx, JS::NewPromiseObject(cx, nullptr));
+  if (!response_promise) {
+    return false;
+  }
+
+  rval.setObject(*response_promise);
+
+  // 1. Let blobURLEntry be request's current URL's blob URL entry.
+  RootedString blob_url(cx);
+
+  // 2. If request's method is not `GET` or blobURLEntry is null, then return a network error.
+  if (std::memcmp(method.ptr.get(), "GET", method.len) != 0) {
+    return api::throw_error(cx, FetchErrors::FetchNetworkError);
+  }
+
+  // 3. Let requestEnvironment be the result of determining the environment given request.
+  // 4. Let isTopLevelNavigation be true if request's destination is "document"; otherwise, false.
+  // 5. If isTopLevelNavigation is false and requestEnvironment is null, then return a network error.
+  // 6. Let navigationOrEnvironment be the string "navigation" if isTopLevelNavigation is true;
+  //  otherwise, requestEnvironment.
+  //  N/A
+  // 7. Let blob be the result of obtaining a blob object given blobURLEntry and
+  // navigationOrEnvironment.
+  std::string url_key(url.ptr.get());
+  RootedObject blob(cx, URL::getObjectURL(url_key));
+
+  // 8. If blob is not a Blob object, then return a network error.
+  if (!blob || !Blob::is_instance(blob)) {
+    return api::throw_error(cx, FetchErrors::FetchNetworkError);
+  }
+
+  // 9. Let response be a new response.
+  RootedObject response_obj(cx, Response::create(cx));
+  if (!response_obj) {
+    return false;
+  }
+
+  // 10. Let fullLength be blob's size.
+  auto full_len = Blob::blob_size(blob);
+  // 11. Let serializedFullLength be fullLength, serialized and isomorphic encoded.
+  // 12. Let type be blob's type.
+  RootedString type(cx, Blob::type(blob));
+
+  JS::RootedObject req_headers(cx, RequestOrResponse::headers(cx, request_obj));
+  if (!req_headers) {
+    return false;
+  }
+
+  auto maybe_range_index = Headers::lookup(cx, req_headers, "Range");
+
+  // 13. If request's header list does not contain `Range`:
+  if (!maybe_range_index.has_value()) {
+    // 1. Let bodyWithType be the result of safely extracting blob.
+    RootedValue body_val(cx, JS::ObjectValue(*blob));
+    RootedValue init_val(cx);
+    if (!Response::initialize(cx, response_obj, body_val, init_val)) {
+      return false;
+    }
+
+    // 2. Set response's status message to `OK`.
+    Response::set_status_message_from_code(cx, response_obj, 200);
+
+    // 3. Set response's body to bodyWithType's body.
+    // 4. Set response's header list to (`Content-Length`, serializedFullLength), (`Content-Type`, type).
+    // 3 and 4 done at the end.
+  // 14. Otherwise:
+  } else {
+    // 1. Set response's range-requested flag.
+    // 2. Let rangeHeader be the result of getting `Range` from request's header list.
+    // 3. Let rangeValue be the result of parsing a single range header value given rangeHeader and true.
+    // 4. If rangeValue is failure, then return a network error.
+    auto *headers = Headers::get_index(cx, req_headers, maybe_range_index.value());
+    MOZ_ASSERT(headers);
+
+    auto &[key, val] = *headers;
+    std::string_view range_value(val);
+
+    if (!range_value.starts_with("bytes=")) {
+      return api::throw_error(cx, FetchErrors::FetchNetworkError);
+    }
+
+    range_value.remove_prefix(6); // bytes=
+    auto dash_pos = range_value.find('-');
+
+    if (dash_pos == std::string_view::npos) {
+      return api::throw_error(cx, FetchErrors::FetchNetworkError);
+    }
+
+    auto start_str = range_value.substr(0, dash_pos);
+    auto end_str = range_value.substr(dash_pos + 1);
+
+    auto to_size = [](std::string_view s) -> std::optional<size_t> {
+      size_t v;
+      auto [ptr, ec] = std::from_chars(s.begin(), s.end(), v);
+      return ec == std::errc() ? std::optional<size_t>(v) : std::nullopt;
+    };
+
+    //   5. Let (rangeStart, rangeEnd) be rangeValue.
+    auto maybe_start_range = to_size(start_str);
+    auto maybe_end_range = to_size(end_str);
+
+    size_t start_range = 0;
+    size_t end_range = 0;
+
+    // 6. If rangeStart is null:
+    if (!maybe_start_range.has_value()) {
+      // If both start_range and end_range are not provided, it's an error.
+      if (!maybe_end_range.has_value()) {
+        return api::throw_error(cx, FetchErrors::FetchNetworkError);
+      }
+
+      // 1. Set rangeStart to fullLength - rangeEnd.
+      // 2. Set rangeEnd to rangeStart + rangeEnd - 1.
+      start_range = full_len - maybe_end_range.value();
+      end_range = start_range + maybe_end_range.value() - 1;
+      // 7. Otherwise:
+    } else {
+      // 1. If rangeStart is greater than or equal to fullLength, then return a network error.
+      if (maybe_start_range.value() > full_len) {
+        return api::throw_error(cx, FetchErrors::FetchNetworkError);
+      }
+      // 2. If rangeEnd is null or rangeEnd is greater than or equal to fullLength, then set
+      // rangeEnd to fullLength - 1.
+      start_range = maybe_start_range.value();
+      end_range = std::min(maybe_end_range.value_or(full_len - 1), full_len - 1);
+    }
+
+    // 8. Let slicedBlob be the result of invoking slice blob given blob, rangeStart, rangeEnd + 1, and type.
+    // 9. Let slicedBodyWithType be the result of safely extracting slicedBlob.
+    // 10. Set response's body to slicedBodyWithType's body.
+    // 11. Let serializedSlicedLength be slicedBlob's size, serialized and isomorphic encoded.
+
+    /// TODO: fix blob API so that we can pass start,end values directly
+    JS::Value vp[4];
+    vp[2].setInt32(start_range);
+    vp[3].setInt32(end_range + 1);
+    auto args = CallArgsFromVp(2, vp);
+
+    RootedValue sliced_blob_val(cx);
+    if (!Blob::slice(cx, blob, args, &sliced_blob_val)) {
+      return false;
+    }
+
+    RootedValue init_val(cx);
+    if (!Response::initialize(cx, response_obj, sliced_blob_val, init_val)) {
+      return false;
+    }
+
+    //   12. Let contentRange be the result of invoking build a content range given rangeStart,
+    //   rangeEnd, and fullLength.
+    //   13. Set response's status to 206.
+    //   14. Set response's status message to `Partial Content`.
+    Response::set_status(response_obj, 206);
+    Response::set_status_message_from_code(cx, response_obj, 206);
+    //   15. Set response's header list to  (`Content-Length`, serializedSlicedLength),
+    //   (`Content-Type`, type), (`Content-Range`, contentRange).
+
+    JS::RootedObject resp_headers(cx, RequestOrResponse::headers(cx, response_obj));
+    if (!resp_headers) {
+      return false;
+    }
+
+    auto content_range_str = fmt::format("bytes {}-{}/{}", start_range, end_range, full_len);
+    if (!Headers::set_valid_if_undefined(cx, resp_headers, "Content-Range", content_range_str)) {
+      return false;
+    }
+
+    // overwrite full_len with sliced blob length so it's written to headers
+    full_len = Blob::blob_size(&sliced_blob_val.toObject());
+  }
+
+  JS::RootedObject resp_headers(cx, RequestOrResponse::headers(cx, response_obj));
+  if (!resp_headers) {
+    return false;
+  }
+
+  auto full_len_str = std::to_string(full_len);
+  if (!Headers::set_valid_if_undefined(cx, resp_headers, "Content-Length", full_len_str)) {
+    return false;
+  }
+
+  auto chars = core::encode(cx, type);
+  if (!chars) {
+    return false;
+  }
+
+  auto type_str = JS::GetStringLength(type) ? chars.ptr.get() : "";
+  if (!Headers::set_valid_if_undefined(cx, resp_headers, "Content-Type", type_str)) {
+    return false;
+  }
+
+  // Blob response type is "basic"
+  JS::SetReservedSlot(response_obj, static_cast<uint32_t>(Response::Slots::Type),
+                      JS::Int32Value(Response::Type::Basic));
+
+  // 15. Return response.
+  JS::RootedValue result(cx);
+  result.setObject(*response_obj);
+  JS::ResolvePromise(cx, response_promise, result);
+
+  return true;
+}
 
 // TODO: throw in all Request methods/getters that rely on host calls once a
 // request has been sent. The host won't let us act on them anymore anyway.
@@ -39,64 +336,36 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
   }
 
   RootedString method_str(cx, Request::method(request_obj));
-  host_api::HostString method = core::encode(cx, method_str);
+  HostString method = core::encode(cx, method_str);
   if (!method.ptr) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
   RootedValue url_val(cx, RequestOrResponse::url(request_obj));
-  host_api::HostString url = core::encode(cx, url_val);
+  HostString url = core::encode(cx, url_val);
   if (!url.ptr) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 
-  unique_ptr<host_api::HttpHeaders> headers =
-      RequestOrResponse::headers_handle_clone(cx, request_obj);
-  if (!headers) {
-    return ReturnPromiseRejectedWithPendingError(cx, args);
-  }
-
-  auto request = host_api::HttpOutgoingRequest::make(method, std::move(url), std::move(headers));
-  MOZ_RELEASE_ASSERT(request);
-  JS_SetReservedSlot(request_obj, static_cast<uint32_t>(Request::Slots::Request),
-                     PrivateValue(request));
-
-  RootedObject response_promise(cx, JS::NewPromiseObject(cx, nullptr));
-  if (!response_promise)
-    return ReturnPromiseRejectedWithPendingError(cx, args);
-
-  bool streaming = false;
-  if (!RequestOrResponse::maybe_stream_body(cx, request_obj, request, &streaming)) {
-    return false;
-  }
-  if (streaming) {
-    // Ensure that the body handle is stored before making the request handle invalid by sending it.
-    request->body();
-  }
-
-  host_api::FutureHttpIncomingResponse *pending_handle;
-  {
-    auto res = request->send();
-    if (auto *err = res.to_err()) {
-      HANDLE_ERROR(cx, *err);
+  switch (scheme_from_url(url).value_or(FetchScheme::Https)) {
+  case FetchScheme::Blob: {
+    auto res = fetch_blob(cx, request_obj, std::move(method), std::move(url), args.rval());
+    if (!res) {
       return ReturnPromiseRejectedWithPendingError(cx, args);
     }
-
-    pending_handle = res.unwrap();
+    break;
+  }
+  case FetchScheme::Http:
+  case FetchScheme::Https:
+  default: {
+    auto res = fetch_https(cx, request_obj, std::move(method), std::move(url), args.rval());
+    if (!res) {
+      return ReturnPromiseRejectedWithPendingError(cx, args);
+    }
+    break;
+  }
   }
 
-  // If the request body is streamed, we need to wait for streaming to complete
-  // before marking the request as pending.
-  if (!streaming) {
-    ENGINE->queue_async_task(new ResponseFutureTask(request_obj, pending_handle));
-  }
-
-  SetReservedSlot(request_obj, static_cast<uint32_t>(Request::Slots::ResponsePromise),
-                  ObjectValue(*response_promise));
-  SetReservedSlot(request_obj, static_cast<uint32_t>(Request::Slots::PendingResponseHandle),
-                  PrivateValue(pending_handle));
-
-  args.rval().setObject(*response_promise);
   return true;
 }
 

--- a/builtins/web/fetch/fetch-utils.cpp
+++ b/builtins/web/fetch/fetch-utils.cpp
@@ -1,0 +1,62 @@
+#include "fetch-utils.h"
+
+#include <string>
+#include <charconv>
+
+namespace builtins::web::fetch {
+
+std::optional<std::tuple<size_t, size_t>> extract_range(std::string_view range_query, size_t full_len) {
+  if (!range_query.starts_with("bytes=")) {
+    return std::nullopt;
+  }
+
+  range_query.remove_prefix(6); // bytes=
+  auto dash_pos = range_query.find('-');
+
+  if (dash_pos == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  auto start_str = range_query.substr(0, dash_pos);
+  auto end_str = range_query.substr(dash_pos + 1);
+
+  auto to_size = [](std::string_view s) -> std::optional<size_t> {
+    size_t v;
+    auto [ptr, ec] = std::from_chars(s.begin(), s.end(), v);
+    return ec == std::errc() ? std::optional<size_t>(v) : std::nullopt;
+  };
+
+  //   5. Let (rangeStart, rangeEnd) be rangeValue.
+  auto maybe_start_range = to_size(start_str);
+  auto maybe_end_range = to_size(end_str);
+
+  size_t start_range = 0;
+  size_t end_range = 0;
+
+  // 6. If rangeStart is null:
+  if (!maybe_start_range.has_value()) {
+    // If both start_range and end_range are not provided, it's an error.
+    if (!maybe_end_range.has_value()) {
+      return std::nullopt;
+    }
+
+    // 1. Set rangeStart to fullLength - rangeEnd.
+    // 2. Set rangeEnd to rangeStart + rangeEnd - 1.
+    start_range = full_len - maybe_end_range.value();
+    end_range = start_range + maybe_end_range.value() - 1;
+    // 7. Otherwise:
+  } else {
+    // 1. If rangeStart is greater than or equal to fullLength, then return a network error.
+    if (maybe_start_range.value() > full_len) {
+      return std::nullopt;
+    }
+    // 2. If rangeEnd is null or rangeEnd is greater than or equal to fullLength, then set
+    // rangeEnd to fullLength - 1.
+    start_range = maybe_start_range.value();
+    end_range = std::min(maybe_end_range.value_or(full_len - 1), full_len - 1);
+  }
+
+  return std::optional<std::tuple<size_t, size_t>>{{start_range, end_range}};
+}
+
+}

--- a/builtins/web/fetch/fetch-utils.h
+++ b/builtins/web/fetch/fetch-utils.h
@@ -1,0 +1,21 @@
+#ifndef FETCH_UTILS_H_
+#define FETCH_UTILS_H_
+
+#include "builtin.h"
+
+namespace builtins::web::fetch {
+
+// Extracts a valid byte range from the given `Range` header query string, following
+// the steps defined for "blob" schemes in the Fetch specification:
+// https://fetch.spec.whatwg.org/#scheme-fetch
+//
+// @param range_query  The raw `Range` header value (e.g. "bytes=0-499").
+// @param full_len     The total size of the resource for which the range is requested.
+//
+// @return An optional tuple `(start, end)` representing the byte range. Returns
+//         `std::nullopt` if the range is invalid or cannot be parsed.
+std::optional<std::tuple<size_t, size_t>> extract_range(std::string_view range_query, size_t full_len);
+
+}
+
+#endif // FETCH_UTILS_H_

--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -1160,7 +1160,7 @@ std::tuple<host_api::HostString, host_api::HostString> *
 Headers::get_index(JSContext *cx, JS::HandleObject self, size_t index) {
   MOZ_ASSERT(is_instance(self));
   std::vector<size_t> *headers_sort_list = Headers::headers_sort_list(self);
-  HeadersList *headers_list = Headers::headers_list(self);
+  HeadersList *headers_list = Headers::get_list(cx, self);
 
   ensure_updated_sort_list(headers_list, headers_sort_list);
   MOZ_RELEASE_ASSERT(index < headers_sort_list->size());
@@ -1170,7 +1170,7 @@ Headers::get_index(JSContext *cx, JS::HandleObject self, size_t index) {
 
 std::optional<size_t> Headers::lookup(JSContext *cx, HandleObject self, string_view key) {
   MOZ_ASSERT(is_instance(self));
-  const HeadersList *headers_list = Headers::headers_list(self);
+  const HeadersList *headers_list = Headers::get_list(cx, self);
   std::vector<size_t> *headers_sort_list = Headers::headers_sort_list(self);
 
   ensure_updated_sort_list(headers_list, headers_sort_list);

--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -1813,6 +1813,16 @@ host_api::HttpResponse *Response::maybe_response_handle(JSObject *obj) {
   return static_cast<host_api::HttpResponse *>(base);
 }
 
+Response::Type Response::type(JSObject *obj) {
+  MOZ_ASSERT(is_instance(obj));
+  return (Type)JS::GetReservedSlot(obj, static_cast<uint32_t>(Slots::Type)).toInt32();
+}
+
+void Response::set_type(JSObject *obj, Response::Type type) {
+  MOZ_ASSERT(is_instance(obj));
+  JS::SetReservedSlot(obj, static_cast<uint32_t>(Slots::Type), JS::Int32Value(type));
+}
+
 uint16_t Response::status(JSObject *obj) {
   MOZ_ASSERT(is_instance(obj));
   return (uint16_t)JS::GetReservedSlot(obj, static_cast<uint32_t>(Slots::Status)).toInt32();

--- a/builtins/web/fetch/request-response.h
+++ b/builtins/web/fetch/request-response.h
@@ -193,8 +193,12 @@ public:
     Status = static_cast<int>(RequestOrResponse::Slots::Count),
     StatusMessage,
     Redirected,
+    Type,
     Count,
   };
+
+  enum Type { Basic, Cors, Default, Error, Opaque, OpaqueRedirect };
+
   static const JSFunctionSpec static_methods[];
   static const JSPropertySpec static_properties[];
   static const JSFunctionSpec methods[];
@@ -206,12 +210,16 @@ public:
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
 
   static JSObject *create(JSContext *cx);
+  static bool initialize(JSContext *cx, JS::HandleObject response, JS::HandleValue body_val,
+                         JS::HandleValue init_val);
+
   static JSObject *init_slots(HandleObject response);
   static JSObject *create_incoming(JSContext *cx, host_api::HttpIncomingResponse *response);
 
   static host_api::HttpResponse *maybe_response_handle(JSObject *obj);
   static uint16_t status(JSObject *obj);
   static JSString *status_message(JSObject *obj);
+  static void set_status(JSObject *obj, uint16_t status);
   static void set_status_message_from_code(JSContext *cx, JSObject *obj, uint16_t code);
 };
 

--- a/builtins/web/fetch/request-response.h
+++ b/builtins/web/fetch/request-response.h
@@ -198,6 +198,7 @@ public:
   };
 
   enum Type { Basic, Cors, Default, Error, Opaque, OpaqueRedirect };
+  using Type = enum Type;
 
   static const JSFunctionSpec static_methods[];
   static const JSPropertySpec static_properties[];
@@ -217,8 +218,10 @@ public:
   static JSObject *create_incoming(JSContext *cx, host_api::HttpIncomingResponse *response);
 
   static host_api::HttpResponse *maybe_response_handle(JSObject *obj);
+  static Type type(JSObject *obj);
   static uint16_t status(JSObject *obj);
   static JSString *status_message(JSObject *obj);
+  static void set_type(JSObject *obj, Type type);
   static void set_status(JSObject *obj, uint16_t status);
   static void set_status_message_from_code(JSContext *cx, JSObject *obj, uint16_t code);
 };

--- a/builtins/web/url.cpp
+++ b/builtins/web/url.cpp
@@ -562,7 +562,7 @@ bool URL::createObjectURL(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto uuid = maybe_uuid.value();
   result.append(uuid);
 
-  RootedString url(cx, JS_NewStringCopyN(cx, result.c_str(), result.size()));
+  RootedString url(cx, JS_NewStringCopyN(cx, result.data(), result.size()));
   if (!url) {
     return false;
   }

--- a/builtins/web/url.cpp
+++ b/builtins/web/url.cpp
@@ -1,13 +1,25 @@
-#include "js/Array.h"
-
+#include "blob.h"
 #include "encode.h"
+#include "file.h"
 #include "rust-url.h"
 #include "sequence.hpp"
 #include "url.h"
+#include "worker-location.h"
+
+#include "crypto/uuid.h"
+
+#include "js/Array.h"
+#include "js/AllocPolicy.h"
+#include "js/GCHashTable.h"
+#include "js/TypeDecls.h"
 
 namespace builtins {
 namespace web {
 namespace url {
+
+using blob::Blob;
+using file::File;
+using worker_location::WorkerLocation;
 
 bool URLSearchParamsIterator::next(JSContext *cx, unsigned argc, JS::Value *vp) {
   METHOD_HEADER(0)
@@ -439,6 +451,8 @@ ACCESSOR(username)
 #undef ACCESSOR
 
 const JSFunctionSpec URL::static_methods[] = {
+    JS_FN("createObjectURL", createObjectURL, 1, JSPROP_ENUMERATE),
+    JS_FN("revokeObjectURL", revokeObjectURL, 1, JSPROP_ENUMERATE),
     JS_FS_END,
 };
 
@@ -467,6 +481,137 @@ const JSPropertySpec URL::properties[] = {
     JS_PSGS("username", URL::username_get, URL::username_set, JSPROP_ENUMERATE),
     JS_PS_END,
 };
+
+struct UrlKey {
+  std::string key_;
+
+  UrlKey() {}
+  UrlKey(std::string key) : key_(std::move(key)) {}
+
+  void trace(JSTracer *trc) {}
+};
+
+struct UrlKeyHasher {
+  using Lookup = const std::string&;
+
+  static mozilla::HashNumber hash(Lookup lookup) {
+    return mozilla::HashString(lookup.data());
+  }
+
+  static bool match(const UrlKey& key, Lookup lookup) {
+    return key.key_ == lookup;
+  }
+};
+
+static PersistentRooted<JS::GCHashMap<UrlKey, Heap<JSObject *>, UrlKeyHasher, js::SystemAllocPolicy>> URL_STORE;
+
+bool URL::createObjectURL(JSContext *cx, unsigned argc, JS::Value *vp) {
+  CallArgs args = JS::CallArgsFromVp(argc, vp);
+  if (!args.requireAtLeast(cx, "createObjectURL", 1)) {
+    return false;
+  }
+
+  HandleValue obj_val = args.get(0);
+  if (!obj_val.isObject()) {
+    return false;
+  }
+
+  RootedObject obj(cx, &obj_val.toObject());
+  if (!obj) {
+    return false;
+  }
+
+  if (!Blob::is_instance(obj) && !File::is_instance(obj)) {
+    return false;
+  }
+
+  // To generate a new blob URL, run the following steps:
+  // 1. Let result be the empty string.
+  // 2. Append the string "blob:" to result.
+  std::string result("blob:");
+
+  // 3. Let settings be the current settings object
+  // 4. Let origin be settings’s origin.
+  // 5. Let serialized be the ASCII serialization of origin.
+  // 6. If serialized is "null", set it to an implementation-defined value.
+  RootedObject worker_location(cx, WorkerLocation::url.get());
+  if (worker_location) {
+    RootedValue origin(cx);
+    if (!JS_GetProperty(cx, worker_location, "origin", &origin)) {
+      return false;
+    }
+
+    auto origin_str = RootedString(cx, JS::ToString(cx, origin));
+    if (!origin_str) {
+      return false;
+    }
+
+    auto chars = core::encode(cx, origin_str);
+    result.append(chars.ptr.get());
+  }
+
+  // 7. Append U+0024 SOLIDUS (/) to result.
+  result.append("/");
+
+  // 8. Generate a UUID [RFC4122] as a string and append it to result.
+  auto maybe_uuid = crypto::random_uuid_v4(cx);
+  if (!maybe_uuid.has_value()) {
+    return false;
+  }
+
+  auto uuid = maybe_uuid.value();
+  result.append(uuid);
+
+  RootedString url(cx, JS_NewStringCopyZ(cx, result.c_str()));
+  if (!url) {
+    return false;
+  }
+
+  if (!URL_STORE.get().put(result, obj)) {
+    return false;
+  }
+
+  args.rval().setString(url);
+  return true;
+}
+
+bool URL::revokeObjectURL(JSContext *cx, unsigned argc, JS::Value *vp) {
+  CallArgs args = JS::CallArgsFromVp(argc, vp);
+  if (!args.requireAtLeast(cx, "createObjectURL", 1)) {
+    return false;
+  }
+
+  // The revokeObjectURL(url) static method must run these steps:
+  // 1. Let urlRecord be the result of parsing url.
+  auto chars = core::encode(cx, args.get(0));
+  if (!chars.ptr) {
+    return false;
+  }
+
+  //   2. If urlRecord’s scheme is not "blob", return.
+  //   3. Let entry be urlRecord’s blob URL entry.
+  std::string url_record(chars.ptr.get());
+  if (!url_record.starts_with("blob:")) {
+    return true;
+  }
+
+  // 4. If entry is null, then return.
+  // 5. Let isAuthorized be the result of checking for same-partition blob URL usage with entry and the current settings object.
+  // 6. If isAuthorized is false, then return.
+  // 7. Remove an entry from the Blob URL Store for url.
+  URL_STORE.get().remove(chars.ptr.get());
+  return true;
+}
+
+JSObject *URL::getObjectURL(std::string &url_str) {
+  // To obtain a blob object given a blob URL entry blobUrlEntry:
+  // 1. Let isAuthorized be true.
+  // 2. If environment is not the string "navigation", then set isAuthorized to the result of checking for same-partition blob URL usage with blobUrlEntry and environment.
+  // 3. If isAuthorized is false, then return failure.
+  // 4. Return blobUrlEntry's object.
+  auto url = URL_STORE.get().lookup(url_str);
+  return url ? url->value() : nullptr;
+}
 
 const jsurl::JSUrl *URL::url(JSObject *self) {
   MOZ_ASSERT(is_instance(self));
@@ -611,6 +756,7 @@ JSObject *URL::create(JSContext *cx, JS::HandleObject self, JS::HandleValue url_
 }
 
 bool URL::init_class(JSContext *cx, JS::HandleObject global) {
+  URL_STORE.init(cx);
   return URL::init_class_impl(cx, global);
 }
 

--- a/builtins/web/url.cpp
+++ b/builtins/web/url.cpp
@@ -562,7 +562,7 @@ bool URL::createObjectURL(JSContext *cx, unsigned argc, JS::Value *vp) {
   auto uuid = maybe_uuid.value();
   result.append(uuid);
 
-  RootedString url(cx, JS_NewStringCopyZ(cx, result.c_str()));
+  RootedString url(cx, JS_NewStringCopyN(cx, result.c_str(), result.size()));
   if (!url) {
     return false;
   }

--- a/builtins/web/url.h
+++ b/builtins/web/url.h
@@ -88,6 +88,9 @@ class URL : public FinalizableBuiltinImpl<URL> {
   static bool origin_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool searchParams_get(JSContext *cx, unsigned argc, JS::Value *vp);
 
+  static bool createObjectURL(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool revokeObjectURL(JSContext *cx, unsigned argc, JS::Value *vp);
+
   static bool toString(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool toJSON(JSContext *cx, unsigned argc, JS::Value *vp);
 
@@ -116,6 +119,8 @@ public:
   static bool protocol(JSContext *cx, JS::HandleObject self, JS::MutableHandleValue rval);
   static bool search(JSContext *cx, JS::HandleObject self, JS::MutableHandleValue rval);
   static bool username(JSContext *cx, JS::HandleObject self, JS::MutableHandleValue rval);
+
+  static JSObject *getObjectURL(std::string &url);
 
   static JSObject *create(JSContext *cx, JS::HandleObject self, jsurl::SpecString url_str,
                           const jsurl::JSUrl *base = nullptr);

--- a/cmake/builtins.cmake
+++ b/cmake/builtins.cmake
@@ -73,7 +73,9 @@ add_builtin(
     SRC
         builtins/web/fetch/fetch-api.cpp
         builtins/web/fetch/headers.cpp
-        builtins/web/fetch/request-response.cpp)
+        builtins/web/fetch/request-response.cpp
+    DEPENDENCIES
+        fmt)
 
 add_builtin(
     builtins::web::fetch::fetch_event
@@ -92,6 +94,7 @@ add_builtin(
         builtins/web/crypto/crypto-key-rsa-components.cpp
         builtins/web/crypto/json-web-key.cpp
         builtins/web/crypto/subtle-crypto.cpp
+        builtins/web/crypto/uuid.cpp
     DEPENDENCIES
         OpenSSL::Crypto
         fmt

--- a/cmake/builtins.cmake
+++ b/cmake/builtins.cmake
@@ -72,6 +72,7 @@ add_builtin(
     builtins::web::fetch
     SRC
         builtins/web/fetch/fetch-api.cpp
+        builtins/web/fetch/fetch-utils.cpp
         builtins/web/fetch/headers.cpp
         builtins/web/fetch/request-response.cpp
     DEPENDENCIES

--- a/cmake/compile-flags.cmake
+++ b/cmake/compile-flags.cmake
@@ -17,7 +17,7 @@ list(APPEND CMAKE_EXE_LINKER_FLAGS
 list(JOIN CMAKE_EXE_LINKER_FLAGS " " CMAKE_EXE_LINKER_FLAGS)
 
 list(APPEND CMAKE_CXX_FLAGS
-        -std=gnu++20 -Wall -Werror -Qunused-arguments
+        -std=gnu++20 -Wall -Werror -Qunused-arguments -Wimplicit-fallthrough
         -fno-sized-deallocation -fno-aligned-new -mthread-model single
         -fPIC -fno-rtti -fno-exceptions -fno-math-errno -pipe
         -fno-omit-frame-pointer -funwind-tables -m32

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -272,6 +272,7 @@ Result<Void> HttpHeaders::append(string_view name, string_view value) {
       return Result<Void>::err(154);
     case WASI_HTTP_TYPES_HEADER_ERROR_IMMUTABLE:
       MOZ_ASSERT_UNREACHABLE("Headers should not be immutable");
+      [[fallthrough]];
     default:
       MOZ_ASSERT_UNREACHABLE("Unknown header error type");
     }

--- a/tests/integration/fetch/fetch.js
+++ b/tests/integration/fetch/fetch.js
@@ -53,4 +53,97 @@ export const handler = serveTest(async (t) => {
     await request.text();
     throws(() => request.clone());
   });
+
+  await t.test('blob-partial-fetch', async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const blob = new Blob([data], { type: 'application/octet-stream' });
+    const blobUrl = URL.createObjectURL(blob);
+
+    // Perform a ranged fetch (requesting the first 5 bytes: 0-4)
+    const response = await fetch(blobUrl, {
+      headers: {
+        'Range': 'bytes=0-4'
+      }
+    });
+
+    // Verify status and status text for partial content
+    strictEqual(response.status, 206, 'response.status should be 206 for partial content');
+    strictEqual(response.statusText, 'Partial Content', 'response.statusText should be "Partial Content"');
+
+    // Check headers
+    const contentType = response.headers.get('Content-Type');
+    const contentLength = response.headers.get('Content-Length');
+    const contentRange = response.headers.get('Content-Range');
+
+    strictEqual(contentType, 'application/octet-stream', 'Content-Type matches blob type');
+    strictEqual(contentLength, '5', 'Content-Length matches the length of requested range (5 bytes)');
+    strictEqual(contentRange, 'bytes 0-4/10', 'Content-Range matches requested bytes and total length');
+
+    // Verify returned data
+    const buf = new Uint8Array(await response.arrayBuffer());
+    deepStrictEqual(buf, new Uint8Array([0,1,2,3,4]), 'returned data should match the requested byte range');
+
+    URL.revokeObjectURL(blobUrl);
+  });
+
+  await t.test('blob-partial-fetch-range-open-end', async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const blob = new Blob([data], { type: 'application/octet-stream' });
+    const blobUrl = URL.createObjectURL(blob);
+
+    const response = await fetch(blobUrl, {
+      headers: { 'Range': 'bytes=5-' }
+    });
+
+    strictEqual(response.status, 206, 'Should return partial content for open-ended range');
+    strictEqual(response.statusText, 'Partial Content', 'Should return "Partial Content"');
+
+    const lengthRemaining = data.length - 5; // 5 bytes (indices 5 to 9)
+    strictEqual(response.headers.get('Content-Length'), String(lengthRemaining), 'Content-Length should match the remaining bytes');
+    strictEqual(response.headers.get('Content-Range'), 'bytes 5-9/10', 'Content-Range should reflect the requested segment (5 through end)');
+
+    const buf = new Uint8Array(await response.arrayBuffer());
+    deepStrictEqual(buf, data.slice(5), 'Returned data should match bytes 5 through the end');
+
+    URL.revokeObjectURL(blobUrl);
+  });
+
+  await t.test('blob-partial-fetch-range-open-start', async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const blob = new Blob([data], { type: 'application/octet-stream' });
+    const blobUrl = URL.createObjectURL(blob);
+
+    const response = await fetch(blobUrl, {
+      headers: { 'Range': 'bytes=-5' }
+    });
+
+    strictEqual(response.status, 206, 'Should return 206');
+    strictEqual(response.statusText, 'Partial Content', 'Should return "Partial Content"');
+
+    const lastFive = data.slice(data.length - 5, data.length);
+    strictEqual(response.headers.get('Content-Length'), '5', 'Content-Length should be last 5 bytes');
+    strictEqual(response.headers.get('Content-Range'), 'bytes 5-9/10', 'Content-Range matches the last 5 bytes');
+
+    const buf = new Uint8Array(await response.arrayBuffer());
+    deepStrictEqual(buf, lastFive, 'Returned data should match the last 5 bytes of the resource');
+
+    URL.revokeObjectURL(blobUrl);
+  });
+
+  await t.test('file-fetch', async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const blob = new Blob([data], { type: 'application/octet-stream' });
+    const file = new File([blob], "dummy.txt");
+
+    const fileUrl = URL.createObjectURL(file);
+    const response = await fetch(fileUrl);
+
+    strictEqual(response.status, 200, 'Should return 200');
+    strictEqual(response.statusText, 'OK', 'Should return "OK"');
+
+    const buf = new Uint8Array(await response.arrayBuffer());
+    deepStrictEqual(buf, data, 'Returned data should match data');
+
+    URL.revokeObjectURL(fileUrl);
+  });
 });

--- a/tests/wpt-harness/expectations/fetch/api/basic/request-upload.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/request-upload.any.js.json
@@ -9,7 +9,7 @@
     "status": "PASS"
   },
   "Fetch with POST with Blob body": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Fetch with POST with ArrayBuffer body": {
     "status": "PASS"
@@ -33,7 +33,7 @@
     "status": "PASS"
   },
   "Fetch with POST with Blob body with mime type": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Fetch with POST with ReadableStream containing String": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/basic/scheme-blob.sub.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/scheme-blob.sub.any.js.json
@@ -1,0 +1,56 @@
+{
+  "Fetching [GET] URL.createObjectURL(blob) is OK": {
+    "status": "PASS"
+  },
+  "Fetching [GET] blob:http://www.web-platform.test:8000/ is KO": {
+    "status": "PASS"
+  },
+  "Fetching [POST] URL.createObjectURL(blob) is KO": {
+    "status": "PASS"
+  },
+  "Fetching [OPTIONS] URL.createObjectURL(blob) is KO": {
+    "status": "PASS"
+  },
+  "Fetching [HEAD] URL.createObjectURL(blob) is KO": {
+    "status": "PASS"
+  },
+  "Fetching [PUT] URL.createObjectURL(blob) is KO": {
+    "status": "PASS"
+  },
+  "Fetching [DELETE] URL.createObjectURL(blob) is KO": {
+    "status": "PASS"
+  },
+  "Fetching [INVALID] URL.createObjectURL(blob) is KO": {
+    "status": "PASS"
+  },
+  "Fetching [GET] blob:not-backed-by-a-blob/ is KO": {
+    "status": "PASS"
+  },
+  "Fetching URL.createObjectURL(empty_blob) is OK": {
+    "status": "PASS"
+  },
+  "Fetching URL.createObjectURL(empty_type_blob) is OK": {
+    "status": "PASS"
+  },
+  "Fetching URL.createObjectURL(empty_data_blob) is OK": {
+    "status": "PASS"
+  },
+  "Fetching URL.createObjectURL(invalid_type_blob) is OK": {
+    "status": "FAIL"
+  },
+  "Blob content is not sniffed for a content type [image/png]": {
+    "status": "PASS"
+  },
+  "Blob content is not sniffed for a content type [text/xml]": {
+    "status": "PASS"
+  },
+  "Set content type to the empty string for slice with invalid content type": {
+    "status": "PASS"
+  },
+  "Set content type to the empty string for slice with no content type ": {
+    "status": "PASS"
+  },
+  "Blob.slice should not sniff the content for a content type": {
+    "status": "PASS"
+  }
+}


### PR DESCRIPTION
This adds `URL.createObjectURL` and `URL.revokeObjectURL` static methods to URL as well as support for blob-scheme fetch:
- https://w3c.github.io/FileAPI/#dfn-createObjectURL
- https://fetch.spec.whatwg.org/#scheme-fetch

Some noteworthy changes include:
- move uuid generation function to a separate file so that it can be used outside `crypto` component,
- split main-fetch function into two `fetch-https` and `fetch-blob` functions called based on url scheme,
- implement Range content fetch for blobs,
- add integration tests for content range fetch.

Closes: https://github.com/bytecodealliance/StarlingMonkey/issues/182