### PR TITLE
feat: support generation integer on headers objects

### DIFF
--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -518,7 +518,14 @@ bool prepare_for_entries_modification(JSContext *cx, JS::HandleObject self) {
       SetReservedSlot(self, static_cast<size_t>(Headers::Slots::Handle), PrivateValue(new_handle));
     }
   } else if (mode == Headers::Mode::CachedInContent || mode == Headers::Mode::Uninitialized) {
-    return switch_mode(cx, self, Headers::Mode::ContentOnly);
+    if (!switch_mode(cx, self, Headers::Mode::ContentOnly)) {
+      return false;
+    }
+  }
+  // bump the generation integer
+  uint32_t gen = JS::GetReservedSlot(self, static_cast<uint32_t>(Headers::Slots::Gen)).toInt32();
+  if (gen != UINT32_MAX) {
+    JS::SetReservedSlot(self, static_cast<uint32_t>(Headers::Slots::Gen), JS::Int32Value(gen + 1));
   }
   return true;
 }
@@ -603,6 +610,7 @@ JSObject *Headers::create(JSContext *cx, HeadersGuard guard) {
 
   SetReservedSlot(self, static_cast<uint32_t>(Slots::HeadersList), PrivateValue(nullptr));
   SetReservedSlot(self, static_cast<uint32_t>(Slots::HeadersSortList), PrivateValue(nullptr));
+  SetReservedSlot(self, static_cast<uint32_t>(Slots::Gen), JS::Int32Value(0));
   return self;
 }
 
@@ -649,6 +657,10 @@ bool Headers::init_entries(JSContext *cx, HandleObject self, HandleValue initv) 
   }
 
   return true;
+}
+
+uint32_t Headers::get_generation(JSObject *self) {
+  return JS::GetReservedSlot(self, static_cast<uint32_t>(Headers::Slots::Gen)).toInt32();
 }
 
 bool Headers::get(JSContext *cx, unsigned argc, JS::Value *vp) {

--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -1025,6 +1025,7 @@ bool Headers::constructor(JSContext *cx, unsigned argc, JS::Value *vp) {
                   JS::Int32Value(static_cast<int32_t>(HeadersGuard::None)));
   SetReservedSlot(self, static_cast<uint32_t>(Slots::HeadersList), PrivateValue(nullptr));
   SetReservedSlot(self, static_cast<uint32_t>(Slots::HeadersSortList), PrivateValue(nullptr));
+  SetReservedSlot(self, static_cast<uint32_t>(Slots::Gen), JS::Int32Value(0));
 
   // walk the headers list writing in the ordered normalized case headers (distinct from the wire)
   if (!init_entries(cx, self, headersInit)) {

--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -524,7 +524,7 @@ bool prepare_for_entries_modification(JSContext *cx, JS::HandleObject self) {
   }
   // bump the generation integer
   uint32_t gen = JS::GetReservedSlot(self, static_cast<uint32_t>(Headers::Slots::Gen)).toInt32();
-  if (gen != UINT32_MAX) {
+  if (gen != INT32_MAX) {
     JS::SetReservedSlot(self, static_cast<uint32_t>(Headers::Slots::Gen), JS::Int32Value(gen + 1));
   }
   return true;

--- a/builtins/web/fetch/headers.h
+++ b/builtins/web/fetch/headers.h
@@ -141,7 +141,7 @@ public:
    * Get the generation integer associated with header mutations.
    * Useful for quickly determining if a headers object may have changed since last seen.
    */
-  static uint32_t get_generation(JSObject * self);
+  static uint32_t get_generation(JSObject *self);
 
   /**
    * Returns a cloned handle representing the contents of this Headers object.

--- a/builtins/web/fetch/headers.h
+++ b/builtins/web/fetch/headers.h
@@ -76,6 +76,7 @@ public:
     HeadersSortList,
     Mode,
     Guard,
+    Gen,
     Count,
   };
 
@@ -135,6 +136,12 @@ public:
   /// Depending on the `Mode` the instance is in, this can be a cache or the canonical store for
   /// the headers.
   static HeadersList *get_list(JSContext *cx, HandleObject self);
+
+  /**
+   * Get the generation integer associated with header mutations.
+   * Useful for quickly determining if a headers object may have changed since last seen.
+   */
+  static uint32_t get_generation(JSObject * self);
 
   /**
    * Returns a cloned handle representing the contents of this Headers object.


### PR DESCRIPTION
This adds support for a generation integer associated with headers mutations.

This allows for a quick check to determine if headers have been mutated since last seen by some code, useful for systems that need to store derived data based on headers (currently which we need at Fastly for cache state computations).