### PR TITLE
Deallocate `jsencoding::Decoder` instances

### DIFF
--- a/builtins/web/text-codec/text-decoder.cpp
+++ b/builtins/web/text-codec/text-decoder.cpp
@@ -247,6 +247,15 @@ bool TextDecoder::init_class(JSContext *cx, JS::HandleObject global) {
   return init_class_impl(cx, global);
 }
 
+void TextDecoder::finalize(JS::GCContext *gcx, JSObject *self) {
+  auto decoder = reinterpret_cast<jsencoding::Decoder *>(
+      JS::GetReservedSlot(self, static_cast<uint32_t>(TextDecoder::Slots::Decoder)).toPrivate());
+
+  if (decoder) {
+    jsencoding::decoder_free(decoder);
+  }
+}
+
 } // namespace text_codec
 } // namespace web
 } // namespace builtins

--- a/builtins/web/text-codec/text-decoder.h
+++ b/builtins/web/text-codec/text-decoder.h
@@ -7,7 +7,7 @@ namespace builtins {
 namespace web {
 namespace text_codec {
 
-class TextDecoder final : public BuiltinImpl<TextDecoder> {
+class TextDecoder final : public FinalizableBuiltinImpl<TextDecoder> {
   static bool decode(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool encoding_get(JSContext *cx, unsigned argc, JS::Value *vp);
   static bool fatal_get(JSContext *cx, unsigned argc, JS::Value *vp);
@@ -33,6 +33,7 @@ public:
 
   static bool init_class(JSContext *cx, JS::HandleObject global);
   static bool constructor(JSContext *cx, unsigned argc, JS::Value *vp);
+  static void finalize(JS::GCContext *gcx, JSObject *self);
 };
 
 } // namespace text_codec


### PR DESCRIPTION
This patch fixes potential memory leaks by ensuring the `jsencoding::decoder_free()` is called for `jsencoding::decoder` instances.