### PR TITLE
Filter out invalid header names when initializing Headers instances

### DIFF
--- a/builtins/web/fetch/fetch-api.cpp
+++ b/builtins/web/fetch/fetch-api.cpp
@@ -34,7 +34,7 @@ bool fetch(JSContext *cx, unsigned argc, Value *vp) {
   }
 
   if (!Request::initialize(cx, request_obj, args[0], args.get(1),
-                           Headers::HeadersGuard::Immutable)) {
+                           Headers::HeadersGuard::Request)) {
     return ReturnPromiseRejectedWithPendingError(cx, args);
   }
 

--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -967,6 +967,14 @@ bool Headers::delete_(JSContext *cx, unsigned argc, JS::Value *vp) {
 bool Headers::append_valid_header(JSContext *cx, JS::HandleObject self,
                                   host_api::HostString valid_key, JS::HandleValue value,
                                   const char *fun_name) {
+  bool is_valid;
+  if (!validate_guard(cx, self, valid_key, "Headers constructor", &is_valid)) {
+    return false;
+  }
+  if (!is_valid) {
+    return true;
+  }
+
   auto value_chars = normalize_and_validate_header_value(cx, value, fun_name);
   if (!value_chars.ptr)
     return false;

--- a/tests/wpt-harness/expectations/fetch/api/basic/accept-header.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/accept-header.any.js.json
@@ -3,12 +3,12 @@
     "status": "FAIL"
   },
   "Request through fetch should have 'accept' header with value 'custom/*'": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Request through fetch should have a 'accept-language' header": {
     "status": "FAIL"
   },
   "Request through fetch should have 'accept-language' header with value 'bzh'": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/fetch/api/basic/mode-same-origin.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/mode-same-origin.any.js.json
@@ -1,9 +1,9 @@
 {
   "Fetch ../resources/top.txt with same-origin mode": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Fetch http://web-platform.test:8000/fetch/api/resources/top.txt with same-origin mode": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Fetch https://web-platform.test:8443/fetch/api/resources/top.txt with same-origin mode": {
     "status": "PASS"

--- a/tests/wpt-harness/expectations/fetch/api/basic/request-forbidden-headers.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/request-forbidden-headers.any.js.json
@@ -33,7 +33,7 @@
     "status": "FAIL"
   },
   "Host is a forbidden request header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Keep-Alive is a forbidden request header": {
     "status": "FAIL"
@@ -198,93 +198,93 @@
     "status": "FAIL"
   },
   "header x-http-method-override is forbidden to use value GET,track ": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method is forbidden to use value GET,track ": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-method-override is forbidden to use value GET,track ": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD-OVERRIDE is forbidden to use value GET,track ": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD is forbidden to use value GET,track ": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-METHOD-OVERRIDE is forbidden to use value GET,track ": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method-override is forbidden to use value  connect": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method is forbidden to use value  connect": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-method-override is forbidden to use value  connect": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD-OVERRIDE is forbidden to use value  connect": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD is forbidden to use value  connect": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-METHOD-OVERRIDE is forbidden to use value  connect": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method-override is allowed to use value GETTRACE": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method is allowed to use value GETTRACE": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-method-override is allowed to use value GETTRACE": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD-OVERRIDE is allowed to use value GETTRACE": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD is allowed to use value GETTRACE": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-METHOD-OVERRIDE is allowed to use value GETTRACE": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method-override is allowed to use value GET": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method is allowed to use value GET": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-method-override is allowed to use value GET": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD-OVERRIDE is allowed to use value GET": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD is allowed to use value GET": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-METHOD-OVERRIDE is allowed to use value GET": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method-override is allowed to use value \",TRACE\",": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-http-method is allowed to use value \",TRACE\",": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header x-method-override is allowed to use value \",TRACE\",": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD-OVERRIDE is allowed to use value \",TRACE\",": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-HTTP-METHOD is allowed to use value \",TRACE\",": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "header X-METHOD-OVERRIDE is allowed to use value \",TRACE\",": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/fetch/api/basic/request-headers.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/request-headers.any.js.json
@@ -57,7 +57,7 @@
     "status": "FAIL"
   },
   "Fetch with GET and mode \"cors\" does not need an Origin header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Fetch with POST and mode \"same-origin\" needs an Origin header": {
     "status": "FAIL"


### PR DESCRIPTION
This also fixes small bugs in how requests are created in `fetch` and what `Response#type` returns. Together, these fix a bunch of WPT tests, and this PR also fixes #145.