### PR TITLE
Don't strip name section in RelWithDebInfo builds

### DIFF
--- a/cmake/binaryen.cmake
+++ b/cmake/binaryen.cmake
@@ -9,3 +9,6 @@ set(BINARYEN_URL https://github.com/WebAssembly/binaryen/releases/download/versi
 CPMAddPackage(NAME binaryen URL ${BINARYEN_URL} DOWNLOAD_ONLY TRUE)
 set(BINARYEN_DIR ${CPM_PACKAGE_binaryen_SOURCE_DIR}/bin)
 set(WASM_OPT ${BINARYEN_DIR}/wasm-opt)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cxx-wrapper.in ${CMAKE_BINARY_DIR}/cxx-wrapper)
+set(CMAKE_CXX_COMPILER "${CMAKE_BINARY_DIR}/cxx-wrapper")

--- a/cmake/compile-flags.cmake
+++ b/cmake/compile-flags.cmake
@@ -2,11 +2,6 @@ set(WASI 1)
 set(CMAKE_CXX_STANDARD 20)
 add_compile_definitions("$<$<CONFIG:DEBUG>:DEBUG=1>")
 
-# NOTE: we shadow wasm-opt by adding $(CMAKE_CURRENT_SOURCE_DIR)/scripts to the path, which
-# includes a script called wasm-opt that immediately exits successfully. See
-# that script for more information about why we do this.
-set(ENV{PATH} "${CMAKE_CURRENT_SOURCE_DIR}/scripts:$ENV{PATH}")
-
 list(APPEND CMAKE_EXE_LINKER_FLAGS
         -Wl,-z,stack-size=1048576 -Wl,--stack-first
         -mexec-model=reactor

--- a/scripts/cxx-wrapper.in
+++ b/scripts/cxx-wrapper.in
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Clang doesn't support overriding where wasm-opt is found, and CMake doesn't allow overriding
+# $PATH for linker/compiler invocations. So we use this script to modify $PATH, and
+# scripts/wasm-opt to hide the real wasm-opt from clang.
+PATH="${CMAKE_CURRENT_SOURCE_DIR}/scripts:$PATH" ${CMAKE_CXX_COMPILER} "$@"


### PR DESCRIPTION
We meant to do this already, but in the move to CMake it got broken.

I hope that this fixes #173 🤞🏻