### PR TITLE
Add `just` recipe for serving the js script

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ Once installed, navigate to the project directory and run `just` commands as nee
 just build
 ```
 
+To load a JS script during componentization and serve its output using `Wasmtime`, run:
+``` shell
+just serve <filename>.js
+```
+
 To build and run integration tests run:
 
 ``` shell

--- a/justfile
+++ b/justfile
@@ -49,6 +49,7 @@ clean-all: && do_clean
 componentize script="" outfile="starling.wasm": build
     {{ builddir }}/componentize.sh {{ script }} -o {{ outfile }}
 
+# Componentize and serve script with wasmtime
 serve script: (componentize script)
     wasmtime serve -S common starling.wasm
 

--- a/justfile
+++ b/justfile
@@ -49,13 +49,16 @@ clean-all: && do_clean
 componentize script="" outfile="starling.wasm": build
     {{ builddir }}/componentize.sh {{ script }} -o {{ outfile }}
 
+serve script: (componentize script)
+    wasmtime serve -S common starling.wasm
+
 # Format code using clang-format. Use --fix to fix files inplace
 format *ARGS:
     {{ justdir }}/scripts/clang-format.sh {{ ARGS }}
 
 # Run integration test
-test: (build "integration-test-server")
-    ctest --test-dir {{ builddir }} -j {{ ncpus }} --output-on-failure
+test regex="": (build "integration-test-server")
+    ctest --test-dir {{ builddir }} -j {{ ncpus }} --output-on-failure -R {{ regex }}
 
 # Build web platform test suite
 [group('wpt')]


### PR DESCRIPTION
This recipe will compile `starling.wasm`, componentize and serve the component with `wasmtime`. 