### PR TITLE
stop printing request method to stderr when  is called

### DIFF
--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -1283,7 +1283,6 @@ bool Request::clone(JSContext *cx, unsigned argc, JS::Value *vp) {
   Value url_val = GetReservedSlot(self, static_cast<uint32_t>(Slots::URL));
   SetReservedSlot(new_request, static_cast<uint32_t>(Slots::URL), url_val);
   Value method_val = JS::StringValue(method(self));
-  ENGINE->dump_value(method_val, stderr);
   SetReservedSlot(new_request, static_cast<uint32_t>(Slots::Method), method_val);
 
   // clone operation step 2.


### PR DESCRIPTION
Removes what appears to be a debug print that slipped through.