### PR TITLE
Fix loading of WPT META scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -72,8 +72,8 @@ wpt-test filter="": wpt-build
 
 # Update web platform test expectations
 [group('wpt')]
-wpt-update: wpt-build
-    WPT_FLAGS="--update-expectations" ctest --test-dir {{ builddir }} -R wpt --verbose
+wpt-update filter="": wpt-build
+    WPT_FLAGS="--update-expectations" WPT_FILTER={{ filter }} ctest --test-dir {{ builddir }} -R wpt --verbose
 
 # Run wpt server
 [group('wpt')]

--- a/tests/wpt-harness/expectations/compression/compression-large-flush-output.any.js.json
+++ b/tests/wpt-harness/expectations/compression/compression-large-flush-output.any.js.json
@@ -1,11 +1,11 @@
 {
   "deflate compression with large flush output": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "gzip compression with large flush output": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "deflate-raw compression with large flush output": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/compression/compression-with-detach.tentative.window.js.json
+++ b/tests/wpt-harness/expectations/compression/compression-with-detach.tentative.window.js.json
@@ -1,5 +1,5 @@
 {
   "data should be correctly compressed even if input is detached partway": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/expectations/compression/decompression-with-detach.tentative.window.js.json
+++ b/tests/wpt-harness/expectations/compression/decompression-with-detach.tentative.window.js.json
@@ -1,5 +1,5 @@
 {
   "data should be correctly decompressed even if input is detached partway": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }

--- a/tests/wpt-harness/wpt_builtins.cpp
+++ b/tests/wpt-harness/wpt_builtins.cpp
@@ -1,5 +1,8 @@
 #include "extension-api.h"
 
+#include <encode.h>
+#include <js/CompilationAndEvaluation.h>
+#include <js/SourceText.h>
 #include <url.h>
 #include <worker-location.h>
 
@@ -26,14 +29,36 @@ static bool baseURL_get(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
+/**
+ * Evaluate the given script in the global scope, without creating a new lexical scope.
+ * This is roughly equivalent to how `<script>` tags work in HTML, and hence how
+ * the WPT harness needs to load `META` scripts: otherwise, `let` and `const` bindings
+ * aren't visible to importing code, and the tests break.
+ */
+static bool evalScript(JSContext *cx, unsigned argc, JS::Value *vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+  auto script = core::encode(cx, args.get(0));
+  if (!script) {
+    return false;
+  }
+  JS::SourceText<mozilla::Utf8Unit> source;
+  MOZ_RELEASE_ASSERT(source.init(cx, std::move(script.ptr), script.len));
+  JS::CompileOptions options(cx);
+  options.setNonSyntacticScope(true);
+  return Evaluate(cx, options, source, args.rval());
+}
+
 
 const JSPropertySpec properties[] = {
-  JS_PSGS("baseURL", baseURL_get, baseURL_set, JSPROP_ENUMERATE),
+  JS_PSGS("wpt_baseURL", baseURL_get, baseURL_set, JSPROP_ENUMERATE),
 JS_PS_END};
 
 namespace wpt_support {
 
 bool install(api::Engine* engine) {
+  if (!JS_DefineFunction(engine->cx(), engine->global(), "evalScript", evalScript, 1, 0)) {
+    return false;
+  }
   if (!JS_DefineProperties(engine->cx(), engine->global(), properties)) {
     return false;
   }


### PR DESCRIPTION
WPT tests can load helper scripts using special comments at the top. These scripts need to be loaded as though using a `<script>` tag, which doesn't create a new lexical scope, and hence causes `let` and `const` bindings to be visible in the global scope.

Previously, to simulate this behavior using `eval`, the WPT harness replaced `let` and `const` with `var`. While this worked surprisingly well, it doesn't *always* work.

This commit instead introduces an `evalScript` function available to the harness, which evaluates in a way more closely matching that of script tags.