### PR TITLE
Don't detach chunks of streaming outgoing request bodies

### DIFF
--- a/builtins/web/fetch/fetch-errors.h
+++ b/builtins/web/fetch/fetch-errors.h
@@ -12,6 +12,7 @@ DEF_ERR(InvalidInitArg, JSEXN_TYPEERR, "{0}: |init| parameter can't be converted
 DEF_ERR(NonBodyRequestWithBody, JSEXN_TYPEERR, "Request constructor: HEAD or GET Request cannot have a body", 0)
 DEF_ERR(NonBodyResponseWithBody, JSEXN_TYPEERR, "Response constructor: response with status {0} cannot have a body", 1)
 DEF_ERR(BodyStreamUnusable, JSEXN_TYPEERR, "Can't use a ReadableStream that's locked or has ever been read from or canceled", 0)
+DEF_ERR(IncomingBodyStreamError, JSEXN_TYPEERR, "IO error reading from incoming {0} body", 1)
 DEF_ERR(BodyStreamTeeingFailed, JSEXN_ERR, "Cloning body stream failed", 0)
 DEF_ERR(InvalidStatus, JSEXN_RANGEERR, "{0}: invalid status {1}", 2)
 DEF_ERR(InvalidStreamChunk, JSEXN_TYPEERR, "ReadableStream used as a Request or Response body must produce Uint8Array values", 0)

--- a/tests/e2e/teed-stream-as-outgoing-body/expect_serve_body.txt
+++ b/tests/e2e/teed-stream-as-outgoing-body/expect_serve_body.txt
@@ -1,0 +1,1 @@
+Successfully forwarded

--- a/tests/e2e/teed-stream-as-outgoing-body/expect_serve_stdout.txt
+++ b/tests/e2e/teed-stream-as-outgoing-body/expect_serve_stdout.txt
@@ -1,0 +1,2 @@
+stdout [1] :: Log: [forwarded]: Hello, World!
+stdout [0] :: Log: [tee]: Hello, World!

--- a/tests/e2e/teed-stream-as-outgoing-body/teed-stream-as-outgoing-body.js
+++ b/tests/e2e/teed-stream-as-outgoing-body/teed-stream-as-outgoing-body.js
@@ -1,0 +1,41 @@
+addEventListener('fetch', async (event) => {
+  event.respondWith(handleRequest(event));
+});
+
+async function handleRequest(event) {
+  if (event.request.url.includes('/api/upstream')) {
+    console.log(`[forwarded]: ${await event.request.text()}`)
+    return new Response('Successfully forwarded\n');
+  }
+
+  let controller;
+  let stream = new ReadableStream({
+    start(c) {
+      controller = c;
+    },
+  });
+  const [forwardStream, logStream] = stream.tee();
+
+  const forwardRequest = new Request('/api/upstream', { body: forwardStream, method: "POST" });
+
+  let pending = fetch(forwardRequest);
+  await controller.enqueue(new TextEncoder().encode("Hello, "));
+  await controller.enqueue(new TextEncoder().encode("World!"));
+  await controller.close();
+  const response = await pending;
+  await logRequestBody(logStream);
+  return response;
+}
+
+async function logRequestBody(stream) {
+  let text = "";
+  let decoder = new TextDecoder();
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode(new Uint8Array(), { stream: false });
+  console.log(`[tee]: ${text}`);
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -41,6 +41,7 @@ test_e2e(tla-runtime-resolve)
 test_e2e(tla)
 test_e2e(stream-forwarding)
 test_e2e(multi-stream-forwarding)
+test_e2e(teed-stream-as-outgoing-body)
 
 test_integration(blob)
 test_integration(btoa)


### PR DESCRIPTION
Detachment must only happen for streaming outgoing response bodies, duh!