### PR TITLE
Use Wasmtime's list of forbidden headers

### DIFF
--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -161,17 +161,24 @@ HttpHeaders::HttpHeaders(const HttpHeadersReadOnly &headers) : HttpHeadersReadOn
   this->handle_state_ = std::unique_ptr<HandleState>(new WASIHandle<HttpHeaders>(handle));
 }
 
-// We currently only guard against a single request header, instead of the full list in
-// https://fetch.spec.whatwg.org/#forbidden-request-header.
+// We guard against the list of forbidden headers Wasmtime uses:
+// https://github.com/bytecodealliance/wasmtime/blob/9afc64b4728d6e2067aa52331ff7b1d6f5275b5e/crates/wasi-http/src/types.rs#L273-L284
 static const std::vector forbidden_request_headers = {
-    "host",
+  "connection",
+  "host",
+  "http2-settings",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "transfer-encoding",
+  "upgrade",
 };
 
-// We currently only guard against a single response header, instead of the full list in
-// https://fetch.spec.whatwg.org/#forbidden-request-header.
-static const std::vector forbidden_response_headers = {
-    "host",
-};
+// WASI hosts don't currently make a difference between request and response headers
+// in their lists of forbidden headers.
+static const std::vector forbidden_response_headers = forbidden_request_headers;
 
 const std::vector<const char *> &HttpHeaders::get_forbidden_request_headers() {
   return forbidden_request_headers;

--- a/tests/wpt-harness/expectations/fetch/api/basic/request-forbidden-headers.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/basic/request-forbidden-headers.any.js.json
@@ -12,7 +12,7 @@
     "status": "FAIL"
   },
   "Connection is a forbidden request header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Content-Length is a forbidden request header": {
     "status": "FAIL"
@@ -36,7 +36,7 @@
     "status": "PASS"
   },
   "Keep-Alive is a forbidden request header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Origin is a forbidden request header": {
     "status": "FAIL"
@@ -45,16 +45,16 @@
     "status": "FAIL"
   },
   "TE is a forbidden request header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Trailer is a forbidden request header": {
     "status": "FAIL"
   },
   "Transfer-Encoding is a forbidden request header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Upgrade is a forbidden request header": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Via is a forbidden request header": {
     "status": "FAIL"

--- a/tests/wpt-harness/expectations/fetch/api/request/request-headers.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/request/request-headers.any.js.json
@@ -42,7 +42,7 @@
     "status": "FAIL"
   },
   "Adding invalid request header \"Connection: KO\"": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Adding invalid request header \"Content-Length: KO\"": {
     "status": "FAIL"
@@ -66,7 +66,7 @@
     "status": "PASS"
   },
   "Adding invalid request header \"Keep-Alive: KO\"": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Adding invalid request header \"Origin: KO\"": {
     "status": "FAIL"
@@ -78,16 +78,16 @@
     "status": "FAIL"
   },
   "Adding invalid request header \"TE: KO\"": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Adding invalid request header \"Trailer: KO\"": {
     "status": "FAIL"
   },
   "Adding invalid request header \"Transfer-Encoding: KO\"": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Adding invalid request header \"Upgrade: KO\"": {
-    "status": "FAIL"
+    "status": "PASS"
   },
   "Adding invalid request header \"Via: KO\"": {
     "status": "FAIL"


### PR DESCRIPTION
This avoids situations where we get (poorly handled) errors when trying to create a WASI resource for a `Headers` object containing a forbidden header.

Fixes #214 