### PR TITLE
Add platform support for JS content debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,12 @@ include("openssl")
 include("${HOST_API}/host_api.cmake")
 include("build-crates")
 
+option(ENABLE_JS_DEBUGGER "Enable support for debugging content via a socket connection" ON)
+
 add_library(extension_api INTERFACE include/extension-api.h runtime/encode.h runtime/decode.h)
+if (ENABLE_JS_DEBUGGER)
+    target_compile_definitions(extension_api INTERFACE ENABLE_JS_DEBUGGER)
+endif()
 target_link_libraries(extension_api INTERFACE rust-url spidermonkey)
 target_include_directories(extension_api INTERFACE include deps/include runtime)
 
@@ -58,7 +63,10 @@ add_executable(starling-raw.wasm
         runtime/event_loop.cpp
         runtime/builtin.cpp
         runtime/script_loader.cpp
+        runtime/debugger.cpp
 )
+
+target_link_libraries(starling-raw.wasm PRIVATE host_api extension_api builtins spidermonkey rust-url multipart)
 
 option(USE_WASM_OPT "use wasm-opt to optimize the StarlingMonkey binary" ON)
 
@@ -89,8 +97,6 @@ else()
         )
     endif()
 endif()
-
-target_link_libraries(starling-raw.wasm PRIVATE host_api extension_api builtins spidermonkey rust-url multipart)
 
 # build a compilation cache of ICs
 if(WEVAL)

--- a/builtins/web/fetch/fetch_event.cpp
+++ b/builtins/web/fetch/fetch_event.cpp
@@ -8,6 +8,7 @@
 #include "../dom-exception.h"
 
 #include <allocator.h>
+#include <debugger.h>
 #include <js/SourceText.h>
 
 #include <iostream>
@@ -543,6 +544,7 @@ bool handle_incoming_request(host_api::HttpIncomingRequest *request) {
 
   double total_compute = 0;
 
+  content_debugger::maybe_init_debugger(ENGINE, true);
   dispatch_fetch_event(fetch_event, &total_compute);
 
   bool success = ENGINE->run_event_loop();

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.38.7)
-set(CPM_HASH_SUM "83e5eb71b2bbb8b1f2ad38f1950287a057624e385c238f6087f94cdfc44af9c5")
+set(CPM_DOWNLOAD_VERSION 0.40.5)
+set(CPM_HASH_SUM "c46b876ae3b9f994b4f05a4c15553e0485636862064f1fcc9d8b4f832086bc5d")
 
 # Ensure that the CPM_SOURCE_CACHE is defined and in sync with ENV{CPM_SOURCE_CACHE}
 if (NOT DEFINED CPM_SOURCE_CACHE)

--- a/host-apis/wasi-0.2.0/host_api.cmake
+++ b/host-apis/wasi-0.2.0/host_api.cmake
@@ -3,7 +3,6 @@ add_library(host_api STATIC
         ${HOST_API}/host_call.cpp
         ${HOST_API}/bindings/bindings.c
         ${HOST_API}/bindings/bindings_component_type.o
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/host_api.h
 )
 
 target_link_libraries(host_api PRIVATE spidermonkey)

--- a/host-apis/wasi-0.2.0/host_api.cpp
+++ b/host-apis/wasi-0.2.0/host_api.cpp
@@ -2,6 +2,8 @@
 #include "bindings/bindings.h"
 #include "handles.h"
 
+#include <wasi/libc-environ.h>
+
 static std::optional<wasi_clocks_monotonic_clock_own_pollable_t> immediately_ready;
 
 size_t poll_handles(vector<WASIHandle<host_api::Pollable>::Borrowed> handles) {
@@ -1030,6 +1032,9 @@ void exports_wasi_http_incoming_handler(exports_wasi_http_incoming_request reque
   // that it properly initializes the runtime and installs a request handler.
   if (!REQUEST_HANDLER) {
     init_from_environment();
+  } else {
+    // Resuming a wizer snapshot, so we have to ensure that the environment is reset.
+    __wasilibc_initialize_environ();
   }
   MOZ_ASSERT(REQUEST_HANDLER);
 

--- a/host-apis/wasi-0.2.3/host_api.cmake
+++ b/host-apis/wasi-0.2.3/host_api.cmake
@@ -3,6 +3,7 @@ set(WASI_0_2_0 "${HOST_API}/../wasi-0.2.0")
 add_library(host_api STATIC
         ${WASI_0_2_0}/host_api.cpp
         ${WASI_0_2_0}/host_call.cpp
+        ${HOST_API}/sockets.cpp
         ${HOST_API}/bindings/bindings.c
         ${HOST_API}/bindings/bindings_component_type.o
 )
@@ -11,6 +12,7 @@ target_link_libraries(host_api PRIVATE spidermonkey)
 target_include_directories(host_api PRIVATE include)
 target_include_directories(host_api PRIVATE ${WASI_0_2_0})
 target_include_directories(host_api PUBLIC ${WASI_0_2_0}/include)
+target_include_directories(host_api PUBLIC ${HOST_API}/include)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(ADAPTER "debug")

--- a/host-apis/wasi-0.2.3/include/sockets.h
+++ b/host-apis/wasi-0.2.3/include/sockets.h
@@ -1,0 +1,70 @@
+#ifndef SOCKETS_H
+#define SOCKETS_H
+
+#include "host_api.h"
+
+namespace host_api {
+
+
+/**
+ * \class TCPSocket
+ * \brief A bare-bones representation of a TCP socket, supporting only basic, blocking operations.
+ *
+ * This class provides methods to create, connect, send, and receive data over a TCP socket.
+ */
+class TCPSocket : public Resource {
+protected:
+  TCPSocket(std::unique_ptr<HandleState> state);
+
+public:
+  using AddressIPV4 = std::tuple<uint8_t, uint8_t, uint8_t, uint8_t>;
+  using Port = uint16_t;
+
+  enum IPAddressFamily {
+    IPV4,
+    IPV6,
+  };
+
+  TCPSocket() = delete;
+
+  /**
+   * \brief Factory method to create a TCPSocket.
+   * \param address_family The IP address family (IPv4 or IPv6).
+   * \return A pointer to the created TCPSocket.
+   */
+  static TCPSocket* make(IPAddressFamily address_family);
+
+  ~TCPSocket() override = default;
+
+  /**
+   * \brief Connects the socket to a specified address and port synchronously,
+   *        blocking until the connection is established.
+   * \param address The IPv4 address to connect to.
+   * \param port The port to connect to.
+   * \return True if the connection is successful, false otherwise.
+   */
+  bool connect(AddressIPV4 address, Port port);
+
+  /**
+   * \brief Closes the socket if it is open, no-op otherwise.
+   */
+  void close();
+
+  /**
+   * \brief Sends data over the socket synchronously, blocking until the data is sent.
+   * \param chunk The data to send.
+   * \return True if the data is sent successfully, false otherwise.
+   */
+  bool send(HostString chunk);
+
+  /**
+   * \brief Receives data from the socket.
+   * \param chunk_size The size of the data chunk to receive.
+   * \return The received data as a HostString.
+   */
+  HostString receive(uint32_t chunk_size);
+};
+
+}
+
+#endif //SOCKETS_H

--- a/host-apis/wasi-0.2.3/sockets.cpp
+++ b/host-apis/wasi-0.2.3/sockets.cpp
@@ -1,0 +1,130 @@
+#include "sockets.h"
+
+#include <../wasi-0.2.0/handles.h>
+
+template <> struct HandleOps<host_api::TCPSocket> {
+  using owned = wasi_sockets_tcp_own_tcp_socket_t;
+  using borrowed = wasi_sockets_tcp_borrow_tcp_socket_t;
+};
+
+class TCPSocketHandle final : public WASIHandle<host_api::TCPSocket> {
+  wasi_sockets_instance_network_own_network_t network_;
+  PollableHandle pollable_handle_;
+  wasi_io_streams_own_input_stream_t input_;
+  wasi_io_streams_own_output_stream_t output_;
+
+  friend host_api::TCPSocket;
+
+public:
+  explicit TCPSocketHandle(HandleOps<host_api::TCPSocket>::owned handle)
+      : WASIHandle(handle), pollable_handle_(INVALID_POLLABLE_HANDLE) {
+    network_ = wasi_sockets_instance_network_instance_network();
+  }
+
+  static TCPSocketHandle *cast(HandleState *handle) {
+    return reinterpret_cast<TCPSocketHandle *>(handle);
+  }
+
+  wasi_sockets_tcp_borrow_network_t network() const {
+    return wasi_sockets_tcp_borrow_network_t(network_.__handle);
+  }
+  PollableHandle pollable_handle() {
+    if (pollable_handle_ == INVALID_POLLABLE_HANDLE) {
+      pollable_handle_ = wasi_sockets_tcp_method_tcp_socket_subscribe(borrow()).__handle;
+    }
+    return pollable_handle_;
+  }
+};
+
+namespace host_api {
+
+TCPSocket::TCPSocket(std::unique_ptr<HandleState> state) {
+  this->handle_state_ = std::move(state);
+}
+
+TCPSocket *TCPSocket::make(IPAddressFamily address_family) {
+  wasi_sockets_tcp_create_socket_ip_address_family_t family =
+      address_family == IPV4 ? WASI_SOCKETS_NETWORK_IP_ADDRESS_FAMILY_IPV4
+                             : WASI_SOCKETS_NETWORK_IP_ADDRESS_FAMILY_IPV6;
+  wasi_sockets_tcp_create_socket_own_tcp_socket_t ret;
+  wasi_sockets_tcp_create_socket_error_code_t err;
+  if (!wasi_sockets_tcp_create_socket_create_tcp_socket(family, &ret, &err)) {
+    return nullptr;
+  }
+  return new TCPSocket(std::unique_ptr<HandleState>(new TCPSocketHandle(ret)));
+}
+
+bool TCPSocket::connect(AddressIPV4 address, Port port) {
+  auto state = TCPSocketHandle::cast(handle_state_.get());
+  auto handle = state->borrow();
+  auto addr = wasi_sockets_network_ipv4_address_t(get<0>(address), get<1>(address), get<2>(address),
+                                                  get<3>(address));
+  wasi_sockets_tcp_ip_socket_address_t socket_address = {
+      WASI_SOCKETS_NETWORK_IP_SOCKET_ADDRESS_IPV4, {{port, addr}}};
+  wasi_sockets_tcp_error_code_t err;
+  if (!wasi_sockets_tcp_method_tcp_socket_start_connect(handle, state->network(), &socket_address,
+                                                        &err)) {
+    // TODO: handle error
+    return false;
+  }
+
+  wasi_sockets_tcp_tuple2_own_input_stream_own_output_stream_t streams;
+  while (true) {
+    if (!wasi_sockets_tcp_method_tcp_socket_finish_connect(handle, &streams, &err)) {
+      if (err == WASI_SOCKETS_NETWORK_ERROR_CODE_WOULD_BLOCK) {
+        block_on_pollable_handle(state->pollable_handle());
+        continue;
+      }
+      // TODO: handle error
+      return false;
+    }
+    state->input_ = streams.f0;
+    state->output_ = streams.f1;
+    break;
+  }
+
+  return true;
+}
+void TCPSocket::close() {
+  auto state = TCPSocketHandle::cast(handle_state_.get());
+  if (!state->valid()) {
+    return;
+  }
+  wasi_sockets_tcp_error_code_t err;
+  wasi_sockets_tcp_method_tcp_socket_shutdown(state->borrow(),
+    WASI_SOCKETS_TCP_SHUTDOWN_TYPE_BOTH, &err);
+  wasi_io_streams_output_stream_drop_own(state->output_);
+  wasi_io_streams_input_stream_drop_own(state->input_);
+  if (state->pollable_handle_ != INVALID_POLLABLE_HANDLE) {
+    wasi_io_poll_pollable_drop_own(own_pollable_t{state->pollable_handle_});
+  }
+  wasi_sockets_tcp_tcp_socket_drop_own(state->take());
+}
+
+bool TCPSocket::send(HostString chunk) {
+  auto state = TCPSocketHandle::cast(handle_state_.get());
+  auto borrow = wasi_io_streams_borrow_output_stream(state->output_);
+  bindings_list_u8_t list{reinterpret_cast<uint8_t *>(chunk.ptr.get()), chunk.len};
+  uint64_t capacity = 0;
+  wasi_io_streams_stream_error_t err;
+  if (!wasi_io_streams_method_output_stream_check_write(borrow, &capacity, &err)) {
+    // TODO: proper error handling.
+  }
+  // TODO: proper error handling.
+  MOZ_ASSERT(chunk.len <= capacity);
+  return wasi_io_streams_method_output_stream_write(borrow, &list, &err);
+}
+
+HostString TCPSocket::receive(uint32_t chunk_size) {
+  auto state = TCPSocketHandle::cast(handle_state_.get());
+  auto borrow = wasi_io_streams_borrow_input_stream(state->input_);
+  bindings_list_u8_t ret{};
+  wasi_io_streams_stream_error_t err{};
+  mozilla::DebugOnly<bool> success;
+  success = wasi_io_streams_method_input_stream_blocking_read(borrow, chunk_size, &ret, &err);
+  MOZ_ASSERT(success, "Why you not handle errors");
+  UniqueChars chars((char*)ret.ptr);
+  return HostString(std::move(chars), ret.len);
+}
+
+} // namespace host_api

--- a/include/config-parser.h
+++ b/include/config-parser.h
@@ -13,7 +13,7 @@ class ConfigParser {
 
 public:
   ConfigParser() : config_(std::make_unique<api::EngineConfig>()) {
-    config_->content_script_path = DEFAULT_SCRIPT_PATH;
+    config_->content_script_path = mozilla::Some(DEFAULT_SCRIPT_PATH);
   }
 
   /**
@@ -73,23 +73,25 @@ public:
     for (size_t i = 1; i < args.size(); i++) {
       if (args[i] == "-e" || args[i] == "--eval") {
         if (i + 1 < args.size()) {
-          config_->content_script = args[i + 1];
+          config_->content_script = mozilla::Some(args[i + 1]);
           config_->content_script_path.reset();
           i++;
         }
       } else if (args[i] == "-v" || args[i] == "--verbose") {
         config_->verbose = true;
+      } else if (args[i] == "-d" || args[i] == "--enable-script-debugging") {
+        config_->debugging = true;
       } else if (args[i] == "--legacy-script") {
         config_->module_mode = false;
         if (i + 1 < args.size()) {
-          config_->content_script_path = args[i + 1];
+          config_->content_script_path = mozilla::Some(args[i + 1]);
           i++;
         }
       } else if (args[i].starts_with("--")) {
         std::cerr << "Unknown option: " << args[i] << std::endl;
         exit(1);
       } else {
-        config_->content_script_path = args[i];
+        config_->content_script_path = mozilla::Some(args[i]);
       }
     }
 

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -35,8 +35,8 @@ namespace api {
 class AsyncTask;
 
 struct EngineConfig {
-  optional<std::string> content_script_path;
-  optional<std::string> content_script;
+  mozilla::Maybe<std::string> content_script_path;
+  mozilla::Maybe<std::string> content_script;
   bool module_mode = true;
 
   /**
@@ -46,6 +46,14 @@ struct EngineConfig {
    */
   bool pre_initialize = false;
   bool verbose = false;
+
+  /**
+   * Whether to enable the script debugger. If this is enabled, the runtime will
+   * check for the DEBUGGER_PORT environment variable and try to connect to that
+   * port on localhost if it's set. If that succeeds, it expects the host to send
+   * a script to use as the debugger, using the SpiderMonkey Debugger API.
+   */
+  bool debugging = false;
 
   EngineConfig() = default;
 };
@@ -63,6 +71,7 @@ public:
   JSContext *cx();
   HandleObject global();
   EngineState state();
+  bool debugging_enabled();
 
   void finish_pre_initialization();
 

--- a/runtime/debugger.cpp
+++ b/runtime/debugger.cpp
@@ -1,0 +1,293 @@
+#include <debugger.h>
+
+#include <decode.h>
+#include <encode.h>
+#include <js/CompilationAndEvaluation.h>
+#include <js/SourceText.h>
+#include <string_view>
+
+mozilla::Maybe<std::string> main_path;
+
+namespace SocketErrors {
+DEF_ERR(SendFailed, JSEXN_TYPEERR, "Failed to send message via TCP socket", 0)
+} // namespace SocketErrors
+
+static bool dbg_set_content_path(JSContext *cx, unsigned argc, Value *vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+  auto path = core::encode(cx, args.get(0));
+  if (!path) {
+    return false;
+  }
+
+  main_path = mozilla::Some(path.ptr.release());
+  args.rval().setUndefined();
+  return true;
+}
+
+static bool print_location(JSContext *cx, FILE *fp = stdout) {
+  JS::AutoFilename filename;
+  uint32_t lineno;
+  JS::ColumnNumberOneOrigin column;
+  if (!DescribeScriptedCaller(cx, &filename, &lineno, &column)) {
+    return false;
+  }
+  fprintf(fp, "%s@%u:%u: ", filename.get(), lineno, column.oneOriginValue());
+  return true;
+}
+
+static bool dbg_print(JSContext *cx, unsigned argc, Value *vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+
+  if (!print_location(cx)) {
+    return false;
+  }
+
+  for (size_t i = 0; i < args.length(); i++) {
+    auto str = core::encode(cx, args.get(i));
+    if (!str) {
+      return false;
+    }
+    printf("%.*s", static_cast<int>(str.len), str.begin());
+  }
+
+  printf("\n");
+  fflush(stdout);
+  args.rval().setUndefined();
+  return true;
+}
+
+static bool dbg_assert(JSContext *cx, unsigned argc, Value *vp) {
+  CallArgs args = CallArgsFromVp(argc, vp);
+  if (!ToBoolean(args.get(0))) {
+
+    if (!print_location(cx, stderr)) {
+      return false;
+    }
+
+    if (args.length() > 1) {
+      auto message = core::encode(cx, args.get(1));
+      fprintf(stderr, "Assert failed in debugger: %.*s",
+        static_cast<int>(message.len), message.begin());
+    } else {
+      fprintf(stderr, "Assert failed in debugger");
+    }
+    MOZ_ASSERT(false);
+  }
+  args.rval().setUndefined();
+  return true;
+}
+
+#include "sockets.h"
+
+namespace debugging_socket {
+
+class TCPSocket : public builtins::BuiltinNoConstructor<TCPSocket> {
+  static host_api::TCPSocket *socket(JSObject *self);
+  static bool send(JSContext *cx, unsigned argc, JS::Value *vp);
+  static bool receive(JSContext *cx, unsigned argc, JS::Value *vp);
+
+public:
+  static constexpr const char *class_name = "TCPSocket";
+  enum Slots { TCPSocketHandle, Count };
+
+  static const JSFunctionSpec static_methods[];
+  static const JSPropertySpec static_properties[];
+  static const JSFunctionSpec methods[];
+  static const JSPropertySpec properties[];
+
+  static JSObject *FromSocket(JSContext *cx, host_api::TCPSocket *socket);
+};
+
+host_api::TCPSocket *TCPSocket::socket(JSObject *self) {
+  auto socket_val = JS::GetReservedSlot(self, TCPSocketHandle);
+  return static_cast<host_api::TCPSocket *>(socket_val.toPrivate());
+}
+
+bool TCPSocket::send(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(1);
+  auto chunk = core::encode(cx, args[0]);
+  if (!socket(self)->send(std::move(chunk))) {
+    return api::throw_error(cx, SocketErrors::SendFailed);
+  }
+  return true;
+}
+
+bool TCPSocket::receive(JSContext *cx, unsigned argc, JS::Value *vp) {
+  METHOD_HEADER(1);
+  int32_t chunk_size;
+  if (!ToInt32(cx, args[0], &chunk_size)) {
+    return false;
+  }
+  auto chunk = socket(self)->receive(chunk_size);
+  auto str = core::decode(cx, chunk);
+  if (!str) {
+    return false;
+  }
+  args.rval().setString(str);
+  return true;
+}
+
+JSObject* TCPSocket::FromSocket(JSContext* cx, host_api::TCPSocket* socket) {
+  RootedObject instance(cx, JS_NewObjectWithGivenProto(cx, &class_, proto_obj));
+  if (!instance) {
+    return nullptr;
+  }
+  SetReservedSlot(instance, TCPSocketHandle, PrivateValue(socket));
+  return instance;
+}
+
+const JSFunctionSpec TCPSocket::methods[] = {
+  JS_FN("send", TCPSocket::send, 1, 0),
+  JS_FN("receive", TCPSocket::receive, 1, 0), JS_FS_END
+};
+
+const JSFunctionSpec TCPSocket::static_methods[] = {JS_FS_END};
+const JSPropertySpec TCPSocket::static_properties[] = {JS_PS_END};
+const JSPropertySpec TCPSocket::properties[] = {JS_PS_END};
+
+host_api::HostString read_message(JSContext *cx, host_api::TCPSocket *socket) {
+  auto chunk = socket->receive(128);
+  if (!chunk) {
+    return nullptr;
+  }
+  char *end;
+  uint16_t message_length = std::strtoul(chunk.begin(), &end, 10);
+  if (end == chunk.begin() || *end != '\n') {
+    return nullptr;
+  }
+  std::string message = std::string(end + 1, chunk.end());
+  while (message.size() < message_length) {
+    chunk = socket->receive(message_length - message.size());
+    if (!chunk) {
+      return nullptr;
+    }
+    message.append(chunk.begin(), chunk.end());
+  }
+  return {std::move(message)};
+}
+
+} // namespace debugging_socket
+
+bool initialize_debugger(JSContext *cx, uint16_t port, bool content_already_initialized) {
+  auto socket = host_api::TCPSocket::make(host_api::TCPSocket::IPAddressFamily::IPV4);
+  MOZ_RELEASE_ASSERT(socket, "Failed to create debugging socket");
+  if (!socket->connect({127, 0, 0, 1}, port) || !socket->send("get-session-port")) {
+    printf("Couldn't connect to debugging socket at port %u, continuing without debugging ...\n",
+           port);
+    return true;
+  }
+  auto response = socket->receive(128);
+  if (!response) {
+    printf("Couldn't get debugging session port, continuing without debugging ...\n");
+    return true;
+  }
+  char *end;
+
+  // If StarlingMonkey was loaded with debugging enabled, but no session is active,
+  // we can just silently continue execution.
+  if (string_view{"no-session"}.compare(0, response.len, response) == 0) {
+    return true;
+  }
+
+  uint16_t session_port = std::strtoul(response.begin(), &end, 10);
+  if (end != response.end() || session_port > 65535) {
+    printf("Invalid debugging session port '%*s' received, continuing without debugging ...\n",
+           static_cast<int>(response.len), response.begin());
+    return true;
+  }
+  socket->close();
+
+  socket = host_api::TCPSocket::make(host_api::TCPSocket::IPAddressFamily::IPV4);
+  MOZ_RELEASE_ASSERT(socket, "Failed to create debugging session socket");
+  if (!socket->connect({127, 0, 0, 1}, session_port) || !socket->send("get-debugger")) {
+    printf("Couldn't connect to debugging session socket at port %u, "
+           "continuing without debugging ...\n",
+           session_port);
+    return true;
+  }
+  auto debugging_script = debugging_socket::read_message(cx, socket);
+  if (!debugging_script) {
+    printf("Couldn't get debugger script, continuing without debugging ...\n");
+    return true;
+  }
+
+  JS::RealmOptions options;
+  options.creationOptions()
+      .setStreamsEnabled(true)
+      .setNewCompartmentInSystemZone()
+      .setInvisibleToDebugger(true);
+
+  static JSClass global_class = {"global", JSCLASS_GLOBAL_FLAGS, &JS::DefaultGlobalClassOps};
+  RootedObject global(cx);
+  global = JS_NewGlobalObject(cx, &global_class, nullptr, JS::DontFireOnNewGlobalHook, options);
+  if (!global) {
+    return false;
+  }
+
+  JSAutoRealm ar(cx, global);
+
+  if (!JS_DefineDebuggerObject(cx, global)) {
+    return false;
+  }
+
+  if (!JS_DefineFunction(cx, global, "setContentPath", dbg_set_content_path, 1, 0) ||
+      !JS_DefineFunction(cx, global, "print", dbg_print, 1, 0) ||
+      !JS_DefineFunction(cx, global, "assert", dbg_assert, 1, 0)) {
+    return false;
+  }
+
+  if (!debugging_socket::TCPSocket::init_class_impl(cx, global)) {
+    return false;
+  }
+
+  RootedObject socket_obj(cx, debugging_socket::TCPSocket::FromSocket(cx, socket));
+  if (!socket_obj) {
+    return false;
+  }
+  if (!JS_DefineProperty(cx, global, "socket", socket_obj, JSPROP_READONLY)) {
+    return false;
+  }
+
+  RootedValue val(cx, JS::BooleanValue(content_already_initialized));
+  if (!JS_DefineProperty(cx, global, "contentAlreadyInitialized", val, JSPROP_READONLY)) {
+    return false;
+  }
+
+  JS::SourceText<mozilla::Utf8Unit> source;
+  if (!source.init(cx, std::move(debugging_script.ptr), debugging_script.len)) {
+    return false;
+  }
+
+  JS::CompileOptions opts(cx);
+  opts.setFile("<debugger>");
+  JS::RootedScript script(cx, JS::Compile(cx, opts, source));
+  if (!script) {
+    return false;
+  }
+  RootedValue result(cx);
+  if (!JS_ExecuteScript(cx, script, &result)) {
+    return false;
+  }
+
+  return true;
+}
+
+static bool debugger_initialized = false;
+void content_debugger::maybe_init_debugger(api::Engine * engine, bool content_already_initialized) {
+  if (debugger_initialized || !engine->debugging_enabled()) {
+    return;
+  }
+  debugger_initialized = true;
+  auto port_str = std::getenv("DEBUGGER_PORT");
+  if (port_str) {
+    uint32_t port = std::stoi(port_str);
+    if (!initialize_debugger(engine->cx(), port, content_already_initialized)) {
+      fprintf(stderr, "Error evaluating debugger script\n");
+      exit(1);
+    }
+  }
+}
+
+mozilla::Maybe<std::string_view> content_debugger::replacement_script_path() {
+  return main_path;
+}

--- a/runtime/debugger.h
+++ b/runtime/debugger.h
@@ -1,0 +1,29 @@
+#ifndef DEBUGGER_H
+#define DEBUGGER_H
+#include "extension-api.h"
+
+namespace content_debugger {
+  /**
+   * Establish a debug connection via a TCP socket and start debugging using a debugger script
+   * received via the new connection.
+   * Only active in builds with the `ENABLE_JS_DEBUGGER` CMake option set.
+   *
+   * @param content_already_initialized Whether the content script has already run
+   *
+   * For more detail on using the Debugger API, see
+   * https://firefox-source-docs.mozilla.org/js/Debugger/index.html
+   *
+   * @return the global object that serves as the debugger
+   */
+  void maybe_init_debugger(api::Engine *engine, bool content_already_initialized);
+
+  /**
+   * Get the path to a replacement script to evaluate instead of the content script.
+   * Always returns `false` in builds without the `ENABLE_JS_DEBUGGER` CMake option set.
+   *
+   * @return the path to the replacement script, if any
+   */
+  mozilla::Maybe<std::string_view> replacement_script_path();
+} // namespace content_debugger
+
+#endif // DEBUGGER_H

--- a/runtime/js.cpp
+++ b/runtime/js.cpp
@@ -6,6 +6,7 @@
 #include "extension-api.h"
 #include "config-parser.h"
 #include "host_api.h"
+#include "wasi/libc-environ.h"
 #include "wizer.h"
 #ifdef MEM_STATS
 #include <string>
@@ -71,6 +72,7 @@ void wizen() {
   if (mono_clock_offset < t) {
     mono_clock_offset = t;
   }
+  __wasilibc_deinitialize_environ();
 }
 
 WIZER_INIT(wizen);


### PR DESCRIPTION
This PR introduces platform support for debugging JavaScript. "Platform support" here means that the PR doesn't contain an implementation of an actual debugger. Instead, it adds infrastructure to StarlingMonkey to initiate a debugging session over a TCP socket connection, and to load a JS implementation of an actual debugger via that connection.

The debugger itself works, but isn't quite ready for prime-time, so I'll open it as a draft PR, building on this one.

The debugger requires sort of a double opt-in: StarlingMonkey has to be started with the `-d/--enable-script-debugging` option set, and a port to connect to needs to be provided via the `DEBUGGER_PORT` env var. That ensures that StarlingMonkey will not try to read env vars at runtime without a prior opt-in, and hence will guarantee that it'll continue working in environments that stub out `wasi::environment`.

@andreiltd I think this is in a state where we can land it, and iterate in-tree. The nice thing about doing so would be that from then on, iterating on the debugger implementation doesn't require custom builds of StarlingMonkey anymore, which is why I'd like to land this now, instead of waiting until the debugger has reached maturity, too.