### PR TITLE
Add support for running initialization scripts before content

### DIFF
--- a/componentize.sh.in
+++ b/componentize.sh.in
@@ -9,9 +9,11 @@ aot=@AOT@
 preopen_dir="${PREOPEN_DIR:-}"
 
 usage() {
-  echo "Usage: $(basename "$0")  [--verbose] [--legacy-script] [input.js] [-o output.wasm]"
+  echo "Usage: $(basename "$0")  [--verbose] [-i,--initializer-script-path] [--legacy-script] [input.js] [-o output.wasm]"
   echo "       Providing an input file but no output uses the input base name with a .wasm extension"
   echo "       Providing an output file but no input creates a component without running any top-level script"
+  echo "       Specifying '--verbose' causes the detailed output during initialization and execution"
+  echo "       Specifying '-i' or '--initializer-script-path' allows specifying an initializer script"
   echo "       Specifying '--legacy-script' causes evaluation as a legacy JS script instead of a module"
   exit 1
 }
@@ -24,6 +26,7 @@ fi
 IN_FILE=""
 OUT_FILE=""
 LEGACY_SCRIPT_PARAM=""
+STARLING_ARGS=""
 VERBOSE=0
 
 while [ $# -gt 0 ]
@@ -38,7 +41,12 @@ do
             OUT_FILE="$2"
             shift 2
             ;;
+        -i|--initializer-script-path)
+            STARLING_ARGS="$STARLING_ARGS $1 $2"
+            shift 2
+            ;;
         -v|--verbose)
+            STARLING_ARGS="$1 $STARLING_ARGS"
             VERBOSE=1
             shift
             ;;
@@ -76,9 +84,8 @@ if [[ -n "$IN_FILE" ]]; then
   fi
   echo "Componentizing $IN_FILE into $OUT_FILE"
 
-  STARLING_ARGS="$LEGACY_SCRIPT_PARAM$IN_FILE"
+  STARLING_ARGS="$STARLING_ARGS $LEGACY_SCRIPT_PARAM$IN_FILE"
   if [[ $VERBOSE -ne 0 ]]; then
-      STARLING_ARGS="--verbose $STARLING_ARGS"
       echo "Componentizing with args $STARLING_ARGS"
   fi
 

--- a/include/config-parser.h
+++ b/include/config-parser.h
@@ -77,6 +77,12 @@ public:
           config_->content_script_path.reset();
           i++;
         }
+      }
+      if (args[i] == "-i" || args[i] == "--initializer-script-path") {
+        if (i + 1 < args.size()) {
+          config_->initializer_script_path = mozilla::Some(args[i + 1]);
+          i++;
+        }
       } else if (args[i] == "-v" || args[i] == "--verbose") {
         config_->verbose = true;
       } else if (args[i] == "-d" || args[i] == "--enable-script-debugging") {

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -35,9 +35,18 @@ namespace api {
 class AsyncTask;
 
 struct EngineConfig {
-  mozilla::Maybe<std::string> content_script_path;
-  mozilla::Maybe<std::string> content_script;
+  mozilla::Maybe<std::string> content_script_path = mozilla::Nothing();
+  mozilla::Maybe<std::string> content_script = mozilla::Nothing();
   bool module_mode = true;
+
+  /**
+   * Path to the script to evaluate before the content script.
+   *
+   * This script is evaluated in a separate global and has access to functions not
+   * available to content. It can be used to set up the environment for the content
+   * script, e.g. by registering builtin modules or adding global properties.
+   */
+  mozilla::Maybe<std::string> initializer_script_path = mozilla::Nothing();
 
   /**
    * Whether to evaluate the top-level script in pre-initialization mode or not.
@@ -101,6 +110,15 @@ public:
   bool eval_toplevel(const char *path, MutableHandleValue result);
   bool eval_toplevel(JS::SourceText<mozilla::Utf8Unit> &source, const char *path,
                      MutableHandleValue result);
+
+  /**
+   * Run the script set using the `-i | --initializer-script-path` option.
+   *
+   * This script runs in a separate global, and has access to functions not
+   * available to content. Notably, that includes the ability to define
+   * builtin modules, using the `defineBuiltinModule` function.
+   */
+  bool run_initialization_script();
 
   /**
    * Run the async event loop as long as there's interest registered in keeping it running.

--- a/runtime/debugger.cpp
+++ b/runtime/debugger.cpp
@@ -35,7 +35,7 @@ static bool print_location(JSContext *cx, FILE *fp = stdout) {
   return true;
 }
 
-static bool dbg_print(JSContext *cx, unsigned argc, Value *vp) {
+bool content_debugger::dbg_print(JSContext *cx, unsigned argc, Value *vp) {
   CallArgs args = CallArgsFromVp(argc, vp);
 
   if (!print_location(cx)) {
@@ -231,7 +231,7 @@ bool initialize_debugger(JSContext *cx, uint16_t port, bool content_already_init
   }
 
   if (!JS_DefineFunction(cx, global, "setContentPath", dbg_set_content_path, 1, 0) ||
-      !JS_DefineFunction(cx, global, "print", dbg_print, 1, 0) ||
+      !JS_DefineFunction(cx, global, "print", content_debugger::dbg_print, 1, 0) ||
       !JS_DefineFunction(cx, global, "assert", dbg_assert, 1, 0)) {
     return false;
   }

--- a/runtime/debugger.h
+++ b/runtime/debugger.h
@@ -24,6 +24,8 @@ namespace content_debugger {
    * @return the path to the replacement script, if any
    */
   mozilla::Maybe<std::string_view> replacement_script_path();
+
+  bool dbg_print(JSContext *cx, unsigned argc, Value *vp);
 } // namespace content_debugger
 
 #endif // DEBUGGER_H

--- a/runtime/script_loader.h
+++ b/runtime/script_loader.h
@@ -22,6 +22,15 @@ public:
   bool eval_top_level_script(const char *path, JS::SourceText<mozilla::Utf8Unit> &source,
                              MutableHandleValue result, MutableHandleValue tla_promise);
   bool load_script(JSContext* cx, const char *script_path, JS::SourceText<mozilla::Utf8Unit> &script);
+
+  /**
+   * Load a script without attempting to resolve its path relative to a base path.
+   *
+   * This is useful for loading ancillary scripts without interfering with, or depending on,
+   * the script loader's state as determined by loading and running content scripts.
+   */
+  bool load_resolved_script(JSContext *cx, const char *specifier, const char *resolved_path,
+                            JS::SourceText<mozilla::Utf8Unit> &script);
 };
 
 #endif //SCRIPTLOADER_H

--- a/tests/e2e/init-script/expect_serve_stdout.txt
+++ b/tests/e2e/init-script/expect_serve_stdout.txt
@@ -1,0 +1,1 @@
+stdout [0] :: Log: foo

--- a/tests/e2e/init-script/init-script.js
+++ b/tests/e2e/init-script/init-script.js
@@ -1,0 +1,8 @@
+import { func } from "builtinMod";
+async function handle(event) {
+  console.log(func());
+  return new Response(func());
+}
+
+//@ts-ignore
+addEventListener('fetch', (event) => { event.respondWith(handle(event)) });

--- a/tests/e2e/init-script/init.js
+++ b/tests/e2e/init-script/init.js
@@ -1,0 +1,8 @@
+const builtinMod = {
+    func() {
+        return 'foo';
+    }
+}
+
+defineBuiltinModule('builtinMod', builtinMod);
+print("initialization done");

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -40,7 +40,7 @@ if [ -z "$test_component" ]; then
 
    # Run Wizer
    set +e
-   PREOPEN_DIR="$(dirname $(dirname "$test_dir"))" "$test_runtime/componentize.sh" $componentize_flags "$test_dir/$test_name.js" "$test_component" 1> "$stdout_log" 2> "$stderr_log"
+   PREOPEN_DIR="$(dirname $(dirname "$test_dir"))" "$test_runtime/componentize.sh" $componentize_flags $runtime_args "$test_component" 1> "$stdout_log" 2> "$stderr_log"
    wizer_result=$?
    set -e
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -32,6 +32,11 @@ print_diff_content_on_fail() {
 # Optionally create the test component if not explicitly provided
 if [ -z "$test_component" ]; then
    test_component="$test_dir/$test_name.wasm"
+   runtime_args="$test_dir/$test_name.js"
+   # If the test directory has an init.js, prepend it to the runtime args
+   if [ -f "$test_dir/init.js" ]; then
+     runtime_args="-i $test_dir/init.js $runtime_args"
+   fi
 
    # Run Wizer
    set +e

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -42,6 +42,7 @@ test_e2e(tla)
 test_e2e(stream-forwarding)
 test_e2e(multi-stream-forwarding)
 test_e2e(teed-stream-as-outgoing-body)
+test_e2e(init-script)
 
 test_integration(blob)
 test_integration(btoa)


### PR DESCRIPTION
This adds the ability to run  a script in a separate global before content gets run. This code has access to additional abilities, notably including the `defineBuiltinModule` function.

Building on this will allow us to change ComponentizeJS to support content using imports from `wasi:package-name` module names without rewriting the code first. That in turn will enable support for non-bundled content code.