### PR TITLE
fix: debugger disabling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ if (ENABLE_WPT)
     include("tests/wpt-harness/wpt.cmake")
 endif()
 
-add_executable(starling-raw.wasm
+if (ENABLE_JS_DEBUGGER)
+    add_executable(starling-raw.wasm
         runtime/js.cpp
         runtime/allocator.cpp
         runtime/encode.cpp
@@ -65,7 +66,19 @@ add_executable(starling-raw.wasm
         runtime/builtin.cpp
         runtime/script_loader.cpp
         runtime/debugger.cpp
-)
+    )
+else()
+    add_executable(starling-raw.wasm
+        runtime/js.cpp
+        runtime/allocator.cpp
+        runtime/encode.cpp
+        runtime/decode.cpp
+        runtime/engine.cpp
+        runtime/event_loop.cpp
+        runtime/builtin.cpp
+        runtime/script_loader.cpp
+    )
+endif()
 
 target_link_libraries(starling-raw.wasm PRIVATE host_api extension_api builtins spidermonkey rust-crates)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,30 +55,22 @@ if (ENABLE_WPT)
     include("tests/wpt-harness/wpt.cmake")
 endif()
 
+set(SOURCES
+    runtime/js.cpp
+    runtime/allocator.cpp
+    runtime/encode.cpp
+    runtime/decode.cpp
+    runtime/engine.cpp
+    runtime/event_loop.cpp
+    runtime/builtin.cpp
+    runtime/script_loader.cpp
+)
+
 if (ENABLE_JS_DEBUGGER)
-    add_executable(starling-raw.wasm
-        runtime/js.cpp
-        runtime/allocator.cpp
-        runtime/encode.cpp
-        runtime/decode.cpp
-        runtime/engine.cpp
-        runtime/event_loop.cpp
-        runtime/builtin.cpp
-        runtime/script_loader.cpp
-        runtime/debugger.cpp
-    )
-else()
-    add_executable(starling-raw.wasm
-        runtime/js.cpp
-        runtime/allocator.cpp
-        runtime/encode.cpp
-        runtime/decode.cpp
-        runtime/engine.cpp
-        runtime/event_loop.cpp
-        runtime/builtin.cpp
-        runtime/script_loader.cpp
-    )
+    list(APPEND SOURCES runtime/debugger.cpp)
 endif()
+
+add_executable(starling-raw.wasm ${SOURCES})
 
 target_link_libraries(starling-raw.wasm PRIVATE host_api extension_api builtins spidermonkey rust-crates)
 

--- a/tests/e2e/init-script/init.js
+++ b/tests/e2e/init-script/init.js
@@ -5,4 +5,5 @@ const builtinMod = {
 }
 
 defineBuiltinModule('builtinMod', builtinMod);
-print("initialization done");
+if (typeof print !== 'undefined')
+    print("initialization done");


### PR DESCRIPTION
This fixes disabling the debugger API when not wanting to build the debugger.

I was hitting an issue where this was failing to find the `socket.h` in the Fastly build, and also we do want to keep the build minimal for now while we don't yet support this.