### PR TITLE
docs: Add Riza to the list of production adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,3 +7,4 @@ The list is in alphabetical order._
 | - | - | - | - |
 | [Fastly](https://www.fastly.com) | [@guybedford](https://github.com/guybedford) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Fastly's [JS SDK](https://github.com/fastly/js-compute-runtime) for Compute at edge is powered by StarlingMonkey. |
 | [Fermyon](https://www.fermyon.com/) | [@tschneidereit](https://github.com/tschneidereit) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | [Fermyon Spin](https://www.fermyon.com/spin) supports serverless Wasm apps, using StarlingMonkey for its [Spin JS SDK](https://github.com/fermyon/spin-js-sdk). |
+| [Riza](https://riza.io/) | [@kyleconroy](https://github.com/kyleconroy) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | The [Riza Code Interpreter API](https://docs.riza.io) relies on StarlingMonkey for isolated JavaScript execution. |


### PR DESCRIPTION
We've been happily running StarlingMonkey in production for quite awhile, and didn't realize this page existed!