### PR TITLE
fix: prepare_for_entries_modification ordering

### DIFF
--- a/builtins/web/fetch/headers.cpp
+++ b/builtins/web/fetch/headers.cpp
@@ -836,11 +836,12 @@ bool Headers::append(JSContext *cx, unsigned argc, JS::Value *vp) {
   }
 
   if (is_valid) {
+    // name casing must come from existing name match if there is one.
+    auto idx = Headers::lookup(cx, self, name_chars);
+
     if (!prepare_for_entries_modification(cx, self))
       return false;
 
-    // name casing must come from existing name match if there is one.
-    auto idx = Headers::lookup(cx, self, name_chars);
     if (idx) {
       // set-cookie doesn't combine
       if (header_compare(name_chars, set_cookie_str) == Ordering::Equal) {


### PR DESCRIPTION
There is a bug in Fastly's header implementation where the invariant assertion in the `append_valid_normalized_header` of the header state was failing by calling Headers::lookup after doing the prepare entries for modification step.

Confirmed this resolves the issue in Fastly's test suite.