### PR TITLE
Support stripping a prefix from all file paths

### DIFF
--- a/componentize.sh.in
+++ b/componentize.sh.in
@@ -9,11 +9,12 @@ aot=@AOT@
 preopen_dir="${PREOPEN_DIR:-}"
 
 usage() {
-  echo "Usage: $(basename "$0")  [--verbose] [-i,--initializer-script-path] [--legacy-script] [input.js] [-o output.wasm]"
+  echo "Usage: $(basename "$0")  [--verbose] [-i,--initializer-script-path path] [--strip-path-prefix prefix] [--legacy-script] [input.js] [-o output.wasm]"
   echo "       Providing an input file but no output uses the input base name with a .wasm extension"
   echo "       Providing an output file but no input creates a component without running any top-level script"
   echo "       Specifying '--verbose' causes the detailed output during initialization and execution"
   echo "       Specifying '-i' or '--initializer-script-path' allows specifying an initializer script"
+  echo "       Specifying '--strip-path-prefix' will cause the provided prefix to be stripped from paths in stack traces and the debugger"
   echo "       Specifying '--legacy-script' causes evaluation as a legacy JS script instead of a module"
   exit 1
 }
@@ -42,6 +43,10 @@ do
             shift 2
             ;;
         -i|--initializer-script-path)
+            STARLING_ARGS="$STARLING_ARGS $1 $2"
+            shift 2
+            ;;
+        --strip-path-prefix)
             STARLING_ARGS="$STARLING_ARGS $1 $2"
             shift 2
             ;;

--- a/include/config-parser.h
+++ b/include/config-parser.h
@@ -87,6 +87,11 @@ public:
         config_->verbose = true;
       } else if (args[i] == "-d" || args[i] == "--enable-script-debugging") {
         config_->debugging = true;
+      } else if (args[i] == "--strip-path-prefix") {
+        if (i + 1 < args.size()) {
+          config_->path_prefix = mozilla::Some(args[i + 1]);
+          i++;
+        }
       } else if (args[i] == "--legacy-script") {
         config_->module_mode = false;
         if (i + 1 < args.size()) {

--- a/include/extension-api.h
+++ b/include/extension-api.h
@@ -37,6 +37,7 @@ class AsyncTask;
 struct EngineConfig {
   mozilla::Maybe<std::string> content_script_path = mozilla::Nothing();
   mozilla::Maybe<std::string> content_script = mozilla::Nothing();
+  mozilla::Maybe<std::string> path_prefix = mozilla::Nothing();
   bool module_mode = true;
 
   /**

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -313,7 +313,7 @@ bool create_initializer_global(Engine *engine) {
   return true;
 }
 
-bool init_js() {
+bool init_js(const EngineConfig& config) {
   JS_Init();
 
   JSContext *cx = JS_NewContext(JS::DefaultHeapMaxBytes);
@@ -353,7 +353,7 @@ bool init_js() {
   // generating bytecode for functions.
   // https://searchfox.org/mozilla-central/rev/5b2d2863bd315f232a3f769f76e0eb16cdca7cb0/js/public/CompileOptions.h#571-574
   opts->setForceFullParse();
-  scriptLoader = new ScriptLoader(ENGINE, opts);
+  scriptLoader = new ScriptLoader(ENGINE, opts, config.path_prefix);
 
   // TODO: restore in a way that doesn't cause a dependency on the Performance builtin in the core runtime.
   //   builtins::Performance::timeOrigin.emplace(
@@ -451,7 +451,7 @@ Engine::Engine(std::unique_ptr<EngineConfig> config) {
 
   TRACE("StarlingMonkey engine initializing");
 
-  if (!init_js()) {
+  if (!init_js(*config_.get())) {
     abort("Initializing JS Engine");
   }
 

--- a/runtime/script_loader.h
+++ b/runtime/script_loader.h
@@ -14,7 +14,8 @@
 
 class ScriptLoader {
 public:
-  ScriptLoader(api::Engine* engine, JS::CompileOptions* opts);
+  ScriptLoader(api::Engine *engine, JS::CompileOptions *opts,
+               mozilla::Maybe<std::string> path_prefix);
   ~ScriptLoader();
 
   bool define_builtin_module(const char* id, HandleValue builtin);

--- a/tests/e2e/runtime-err/expect_serve_stderr.txt
+++ b/tests/e2e/runtime-err/expect_serve_stderr.txt
@@ -1,10 +1,10 @@
 stderr [0] :: Error while running request handler: runtime error
 stderr [0] :: Stack:
-stderr [0] ::   @runtime-err.js:6:13
-stderr [0] ::   @runtime-err.js:7:7
+stderr [0] ::   @e2e/runtime-err/runtime-err.js:6:13
+stderr [0] ::   @e2e/runtime-err/runtime-err.js:7:7
 stderr [0] :: 
 stderr [0] :: Caused by: error cause
 stderr [0] :: Stack:
-stderr [0] ::   @runtime-err.js:6:49
-stderr [0] ::   @runtime-err.js:7:7
+stderr [0] ::   @e2e/runtime-err/runtime-err.js:6:49
+stderr [0] ::   @e2e/runtime-err/runtime-err.js:7:7
 stderr [0] :: 

--- a/tests/e2e/syntax-err/expect_wizer_stderr.txt
+++ b/tests/e2e/syntax-err/expect_wizer_stderr.txt
@@ -1,2 +1,2 @@
 Exception while evaluating top-level script
-syntax-err.js:2:1 SyntaxError: expected expression, got end of script
+e2e/syntax-err/syntax-err.js:2:1 SyntaxError: expected expression, got end of script

--- a/tests/e2e/tla-err/expect_wizer_stderr.txt
+++ b/tests/e2e/tla-err/expect_wizer_stderr.txt
@@ -1,2 +1,2 @@
 Exception while evaluating top-level script
-tla-err.js:3:10 Error: blah
+e2e/tla-err/tla-err.js:3:10 Error: blah

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -38,9 +38,13 @@ if [ -z "$test_component" ]; then
      runtime_args="-i $test_dir/init.js $runtime_args"
    fi
 
+   test_top_level="$(dirname $(dirname "$test_dir"))/"
+
+   runtime_args="--strip-path-prefix $test_top_level $runtime_args"
+
    # Run Wizer
    set +e
-   PREOPEN_DIR="$(dirname $(dirname "$test_dir"))" "$test_runtime/componentize.sh" $componentize_flags $runtime_args "$test_component" 1> "$stdout_log" 2> "$stderr_log"
+   PREOPEN_DIR="$test_top_level" "$test_runtime/componentize.sh" $componentize_flags $runtime_args "$test_component" 1> "$stdout_log" 2> "$stderr_log"
    wizer_result=$?
    set -e
 


### PR DESCRIPTION
This introduces the CLI option `--strip-path-prefix prefix` and strips the provided `prefix` from all paths as seen by content, in stack traces, and the debugger.

Previously, we unilaterally stripped the directory part of the top-level script's path instead. This new approach is better in two ways:
1. it works for files that are in ancestor or sibling directories to the top-level script
2. it enables using an ancestor directory as the root

The second of these advantages can be seen in the diffs to the test expectations files: the stacks for those are more informative, because they now include the directory of the actual test, since we're only stripping the `[StarlingMonkey root]/tests` part of the path.