### PR TITLE
Update OpenSSL to version 3.0.16

### DIFF
--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -1,6 +1,6 @@
 # Based on https://stackoverflow.com/a/72187533
-set(OPENSSL_VERSION 3.0.7)
-set(OPENSSL_SOURCE_DIR ${CMAKE_BINARY_DIR}/deps-src/OpenSSL)
+set(OPENSSL_VERSION 3.0.16)
+set(OPENSSL_HASH "SHA256=57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86")
 set(OPENSSL_INSTALL_DIR ${CMAKE_BINARY_DIR}/deps/OpenSSL)
 set(OPENSSL_INCLUDE_DIR ${OPENSSL_INSTALL_DIR}/include)
 include(ExternalProject)
@@ -11,21 +11,24 @@ else()
     find_program(MAKE_COMMAND NAMES make gmake)
 endif()
 
+CPMAddPackage(NAME
+        OpenSSL
+        URL https://openssl.org/source/old/3.0/openssl-${OPENSSL_VERSION}.tar.gz
+        URL_HASH ${OPENSSL_HASH}
+        PATCHES
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/getuid.patch
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/rand.patch
+        DOWNLOAD_ONLY TRUE
+)
 ExternalProject_Add(
         OpenSSL
-        SOURCE_DIR ${OPENSSL_SOURCE_DIR}
-        URL https://openssl.org/source/old/3.0/openssl-${OPENSSL_VERSION}.tar.gz
-        URL_HASH SHA256=83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
-        USES_TERMINAL_DOWNLOAD TRUE
-        PATCH_COMMAND
-        patch -d ${OPENSSL_SOURCE_DIR} -t -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/getuid.patch &&
-        patch -d ${OPENSSL_SOURCE_DIR} -t -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/deps/patches/rand.patch
+        SOURCE_DIR ${OpenSSL_SOURCE_DIR}
         CONFIGURE_COMMAND
-        CC="clang" CFLAGS="--sysroot=${WASI_SDK_PREFIX}/share/wasi-sysroot" ${OPENSSL_SOURCE_DIR}/config
+        CC="clang" CFLAGS="--sysroot=${WASI_SDK_PREFIX}/share/wasi-sysroot" ${OpenSSL_SOURCE_DIR}/config
         --prefix=${OPENSSL_INSTALL_DIR}
         --openssldir=${OPENSSL_INSTALL_DIR}
         -static -no-sock -no-asm -no-ui-console -no-egd
-        -no-afalgeng -no-tests -no-stdio -no-threads
+        -no-afalgeng -no-tests -no-stdio -no-threads no-dso
         -D_WASI_EMULATED_SIGNAL
         -D_WASI_EMULATED_PROCESS_CLOCKS
         -D_WASI_EMULATED_GETPID
@@ -51,5 +54,5 @@ file(MAKE_DIRECTORY ${OPENSSL_INCLUDE_DIR})
 
 add_library(OpenSSL::Crypto STATIC IMPORTED GLOBAL)
 set_property(TARGET OpenSSL::Crypto PROPERTY IMPORTED_LOCATION ${OPENSSL_INSTALL_DIR}/libx32/libcrypto.a)
-set_property(TARGET OpenSSL::Crypto PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${OPENSSL_INCLUDE_DIR})
+target_include_directories(OpenSSL::Crypto INTERFACE ${OPENSSL_INCLUDE_DIR})
 add_dependencies(OpenSSL::Crypto OpenSSL)


### PR DESCRIPTION
This updates OpenSSL to the latest version of the 3.0 release train, from the previous, very old, 3.0.7.

It also moves to using CPM to download and patch the OpenSSL source code, which speeds up building different configurations from the same source tree, and eliminates some issues where reconfiguring caused issues with applying the patches.