### PR TITLE
fix(formData): use headers instead of maybe_headers

### DIFF
--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -616,7 +616,7 @@ bool RequestOrResponse::parse_body(JSContext *cx, JS::HandleObject self, JS::Uni
       return RejectPromiseWithPendingError(cx, result_promise);
     };
 
-    RootedObject headers(cx, RequestOrResponse::maybe_headers(self));
+    RootedObject headers(cx, RequestOrResponse::headers(cx, self));
     if (!headers) {
       return throw_invalid_header();
     }


### PR DESCRIPTION
Something I've noticed is that headers for FormData are sometimes not initialized when we try to parse the request into formData. This ensures that the headers will be initialized if they haven't been already.