### PR TITLE
Fix parsing of the `--eval` CLI option

### DIFF
--- a/include/config-parser.h
+++ b/include/config-parser.h
@@ -77,8 +77,7 @@ public:
           config_->content_script_path.reset();
           i++;
         }
-      }
-      if (args[i] == "-i" || args[i] == "--initializer-script-path") {
+      } else if (args[i] == "-i" || args[i] == "--initializer-script-path") {
         if (i + 1 < args.size()) {
           config_->initializer_script_path = mozilla::Some(args[i + 1]);
           i++;


### PR DESCRIPTION
This patch fixes a bug in the CLI option parser that parses the argument to `--eval` twice, causing runtime initialization to interpret the argument as a script path, rather than an inline script. This is currently causing an example invocation in the README to fail:

```
wasmtime -S http starling.wasm -e "console.log('hello world')"

ReferenceError: Error loading module "console.log('hello world')"
(resolved path "console.log('hello world')"): No such file or directory
```