### PR TITLE
fix(ci): give deploy job write permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 3
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
I'm not sure why I don't need this to deploy gh-pages on my fork, but hopefully this will fix the CI:

https://github.com/bytecodealliance/StarlingMonkey/actions/runs/16442845527/job/46467489433

Another possible issue might be that the workflow permissions for repo (settings > actions > general) are set to read only. I don't have access to verify this.