### PR TITLE
Try fixing release-please permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -56,9 +57,17 @@ jobs:
         run: |
           mkdir -p release-artifacts
 
-          cp build-release/starling-raw.wasm release-artifacts/starling.wasm
-          cp build-weval/starling-raw.wasm release-artifacts/starling-weval.wasm
-          cp build-debug/starling-raw.wasm release-artifacts/starling-debug.wasm
+          # Core-module versions of the runtime
+          cp build-release/starling-raw.wasm release-artifacts/starling-raw.wasm
+          cp build-weval/starling-raw.wasm release-artifacts/starling-raw-weval.wasm
+          cp build-debug/starling-raw.wasm release-artifacts/starling-raw-debug.wasm
+
+          # Component-versions of the runtime
+          cp build-release/starling.wasm release-artifacts/starling.wasm
+          cp build-weval/starling.wasm release-artifacts/starling-weval.wasm
+          cp build-debug/starling.wasm release-artifacts/starling-debug.wasm
+
+          # Supporting artifacts
           cp build-release/preview1-adapter.wasm release-artifacts
           cp build-weval/starling-ics.wevalcache release-artifacts
 


### PR DESCRIPTION
Let's see if this fixes the release permissions. It at least matches the [release-please action's documentation](https://github.com/googleapis/release-please-action#basic-configuration).

In looking at this, I also noticed that the published artifacts aren't quite what I expected—my apologies for not catching this earlier! There's a key difference between the `starling-raw.wasm` and `starling.wasm` builds, and we shouldn't rename the former to the latter for the released artifacts. Instead, I simply added both, so that they can both be made use of directly.