### PR TITLE
fix: deprecation warning in panic hook

### DIFF
--- a/crates/rust-hooks/src/lib.rs
+++ b/crates/rust-hooks/src/lib.rs
@@ -11,10 +11,7 @@ use std::ops::Deref;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::panic;
-#[cfg(feature = "panic_hook")]
 use std::panic::PanicHookInfo;
-#[cfg(not(feature = "panic_hook"))]
-use std::panic::PanicInfo as PanicHookInfo;
 
 #[link(name = "wrappers")]
 extern "C" {


### PR DESCRIPTION
The patch fixes this warning:

```
warning: use of deprecated type alias `std::panic::PanicInfo`: use `PanicHookInfo` instead
  --> /home/runner/work/StarlingMonkey/StarlingMonkey/crates/rust-hooks/src/lib.rs:17:17
   |
17 | use std::panic::PanicInfo as PanicHookInfo;
   |                 ^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
warning: use of deprecated type alias `std::panic::PanicInfo`: use `PanicHookInfo` instead
  --> /home/runner/work/StarlingMonkey/StarlingMonkey/crates/rust-hooks/src/lib.rs:73:22
   |
73 | fn panic_hook(info: &PanicHookInfo) {
   |                      ^^^^^^^^^^^^^
warning: `rust-hooks` (lib) generated 2 warnings
```