### PR TITLE
ci: More release-please fixes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "release-type": "simple",
+  "separate-pull-requests": true,
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "include-v-in-tag": true,
@@ -7,6 +7,7 @@
   "packages": {
     ".": {
       "package-name": "starlingmonkey",
+      "release-type": "simple",
       "exclude-paths": ["debugger/vscode-dap-extension/**"]
     },
     "debugger/vscode-dap-extension": {


### PR DESCRIPTION
Creating separate PRs is something I had missed in the config. The other change is to make sure the release-type is applied correctly. I think it already was, but this seems better scoped regardless.

Surely this must be it!