### PR TITLE
chore(ci): hide debugger changes in main changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,14 @@
     ".": {
       "package-name": "starlingmonkey",
       "release-type": "simple",
-      "exclude-paths": ["debugger/vscode-dap-extension/**"]
+      "exclude-paths": ["debugger/vscode-dap-extension/**"],
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "feat", "scope": "debugger", "hidden": true },
+        { "type": "fix", "scope": "debugger", "hidden": true },
+        { "type": "chore", "scope": "debugger", "hidden": true }
+      ]
     },
     "debugger/vscode-dap-extension": {
       "package-name": "starlingmonkey-debugger",


### PR DESCRIPTION
release-please's `exclude-paths` setting makes it so that changes to those paths don't trigger a release for the given package. Unfortunately, it doesn't make it so changes aren't added to the changelog. So instead, let's hide changes scoped to `debugger`.

We can, as it turns out, always edit the changelog in the release PR, so this doesn't have to be 100% foolproof.