### PR TITLE
chore(deps): bump weval

### DIFF
--- a/cmake/weval.cmake
+++ b/cmake/weval.cmake
@@ -1,4 +1,4 @@
-set(WEVAL_VERSION v0.4.0)
+set(WEVAL_VERSION v0.4.1)
 
 set(WEVAL_URL https://github.com/bytecodealliance/weval/releases/download/${WEVAL_VERSION}/weval-${WEVAL_VERSION}-${HOST_ARCH}-${HOST_OS}.tar.xz)
 CPMAddPackage(NAME weval URL ${WEVAL_URL} DOWNLOAD_ONLY TRUE)


### PR DESCRIPTION
Use the latest release of weval (0.4.1) that includes improvement for memory packing. The componentize.sh script produces 30% smaller binary with new weval.