### PR TITLE
Add Open VSX publishing to extension release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -111,6 +111,10 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+      - name: Publish to Open VSX
+        working-directory: debugger/vscode-dap-extension
+        run: npx ovsx publish *.vsix --pat "${{ secrets.OVSX_PAT }}"
+        
       - name: Upload VSIX to Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 #2.3.2
         with:


### PR DESCRIPTION
This adds a publish step to the `release-please` workflow that uploads the extension to [Open VSX](https://open-vsx.org) alongside the existing Microsoft marketplace publish. Open VSX is used by VS Code-compatible editors that don't have access to the Microsoft marketplace, including code-server and VSCodium.

The change reuses the `.vsix` already produced by the `package` step, so no build changes are needed. The new step uses `ovsx`, which accepts the same artifact.

**Before this will work**, someone with admin access to the org will need to:
  1. Register the `bytecodealliance` namespace on open-vsx.org
  2. Generate an Open VSX PAT and add it to the repo as `OVSX_PAT`

Happy to adjust anything if the approach doesn't fit how you want to manage the release pipeline.