### PR TITLE
fix(fetch): body.blob() sets Blob.type from Content-Type header

### DIFF
--- a/builtins/web/blob.cpp
+++ b/builtins/web/blob.cpp
@@ -26,60 +26,6 @@ template <typename T> bool validate_type(T *chars, size_t strlen) {
   return true;
 }
 
-// 1. If type contains any characters outside the range U+0020 to U+007E, then set t to the empty string.
-// 2. Convert every character in type to ASCII lowercase.
-JSString *normalize_type(JSContext *cx, HandleValue value) {
-  JS::RootedString value_str(cx);
-
-  if (value.isObject() || value.isString()) {
-    value_str = JS::ToString(cx, value);
-    if (!value_str) {
-      return nullptr;
-    }
-  } else if (value.isNull()) {
-    return JS::ToString(cx, value);
-  } else {
-    return JS_GetEmptyString(cx);
-  }
-
-  auto *str = JS::StringToLinearString(cx, value_str);
-  if (!str) {
-    return nullptr;
-  }
-
-  std::string normalized;
-  auto strlen = JS::GetLinearStringLength(str);
-
-  if (strlen == 0U) {
-    return JS_GetEmptyString(cx);
-  }
-
-  if (JS::LinearStringHasLatin1Chars(str)) {
-    JS::AutoCheckCannotGC nogc(cx);
-    const auto *chars = JS::GetLatin1LinearStringChars(nogc, str);
-    if (!validate_type(chars, strlen)) {
-      return JS_GetEmptyString(cx);
-    }
-
-    normalized = std::string(reinterpret_cast<const char *>(chars), strlen);
-  } else {
-    JS::AutoCheckCannotGC nogc(cx);
-    const auto *chars = (JS::GetTwoByteLinearStringChars(nogc, str));
-    if (!validate_type(chars, strlen)) {
-      return JS_GetEmptyString(cx);
-    }
-
-    normalized.reserve(strlen);
-    for (size_t i = 0; i < strlen; ++i) {
-      normalized += static_cast<unsigned char>(chars[i]);
-    }
-  }
-
-  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-
-  return JS_NewStringCopyN(cx, normalized.c_str(), normalized.length());
-}
 
 // https://w3c.github.io/FileAPI/#convert-line-endings-to-native
 std::string convert_line_endings_to_native(std::string_view s) {
@@ -125,6 +71,60 @@ std::string convert_line_endings_to_native(std::string_view s) {
 
 
 namespace builtins::web::blob {
+
+// https://w3c.github.io/FileAPI/#dfn-type
+// 1. If type contains any characters outside the range U+0020 to U+007E, then set t to the empty string.
+// 2. Convert every character in type to ASCII lowercase.
+JSString *Blob::normalize_type(JSContext *cx, JS::HandleValue value) {
+  JS::RootedString value_str(cx);
+
+  if (value.isObject() || value.isString()) {
+    value_str = JS::ToString(cx, value);
+    if (!value_str) {
+      return nullptr;
+    }
+  } else if (value.isNull()) {
+    return JS::ToString(cx, value);
+  } else {
+    return JS_GetEmptyString(cx);
+  }
+
+  auto *str = JS::StringToLinearString(cx, value_str);
+  if (!str) {
+    return nullptr;
+  }
+
+  std::string normalized;
+  auto strlen = JS::GetLinearStringLength(str);
+
+  if (strlen == 0U) {
+    return JS_GetEmptyString(cx);
+  }
+
+  if (JS::LinearStringHasLatin1Chars(str)) {
+    JS::AutoCheckCannotGC nogc(cx);
+    const auto *chars = JS::GetLatin1LinearStringChars(nogc, str);
+    if (!validate_type(chars, strlen)) {
+      return JS_GetEmptyString(cx);
+    }
+    normalized = std::string(reinterpret_cast<const char *>(chars), strlen);
+  } else {
+    JS::AutoCheckCannotGC nogc(cx);
+    const auto *chars = JS::GetTwoByteLinearStringChars(nogc, str);
+    if (!validate_type(chars, strlen)) {
+      return JS_GetEmptyString(cx);
+    }
+    normalized.reserve(strlen);
+    for (size_t i = 0; i < strlen; ++i) {
+      normalized += static_cast<unsigned char>(chars[i]);
+    }
+  }
+
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  return JS_NewStringCopyN(cx, normalized.c_str(), normalized.length());
+}
 
 using js::Vector;
 using streams::BufReader;
@@ -285,7 +285,7 @@ bool Blob::slice(JSContext *cx, HandleObject self, const CallArgs &args, Mutable
 
   if (args.hasDefined(2)) {
     HandleValue contentType_val = args.get(2);
-    if ((contentType = normalize_type(cx, contentType_val)) == nullptr) {
+    if ((contentType = Blob::normalize_type(cx, contentType_val)) == nullptr) {
       return false;
     }
   }
@@ -547,7 +547,7 @@ bool Blob::init_options(JSContext *cx, HandleObject self, HandleValue initv) {
       return false;
     }
 
-    auto *type_str = normalize_type(cx, type);
+    auto *type_str = Blob::normalize_type(cx, type);
     if (!type_str) {
       return false;
     }

--- a/builtins/web/blob.h
+++ b/builtins/web/blob.h
@@ -54,6 +54,7 @@ public:
   static bool read_blob_slice(JSContext *cx, HandleObject self, std::span<uint8_t> buf,
                               size_t start, size_t *read, bool *done);
 
+  static JSString *normalize_type(JSContext *cx, JS::HandleValue value);
   static JSObject *create(JSContext *cx, UniqueChars data, size_t data_len, HandleString type);
 
   static bool init_class(JSContext *cx, HandleObject global);

--- a/builtins/web/fetch/request-response.cpp
+++ b/builtins/web/fetch/request-response.cpp
@@ -611,8 +611,32 @@ bool RequestOrResponse::parse_body(JSContext *cx, JS::HandleObject self, JS::Uni
     result.setObject(*array_buffer);
   } else if constexpr (result_type == RequestOrResponse::BodyReadResult::Blob) {
     JS::RootedString contentType(cx, JS_GetEmptyString(cx));
-    JS::RootedObject blob(cx, blob::Blob::create(cx, std::move(buf), len, contentType));
 
+    RootedObject headers(cx, RequestOrResponse::headers(cx, self));
+    if (!headers) {
+      return RejectPromiseWithPendingError(cx, result_promise);
+    }
+    auto content_type_key = host_api::HostString("Content-Type");
+    auto idx = Headers::lookup(cx, headers, content_type_key);
+    if (idx) {
+      auto *values = Headers::get_index(cx, headers, idx.value());
+      auto maybe_mime = extract_mime_type(std::get<1>(*values));
+      if (!maybe_mime.isErr()) {
+        auto mime_str = maybe_mime.unwrap().to_string();
+        JS::RootedString mime_js_str(cx, JS_NewStringCopyN(cx, mime_str.c_str(), mime_str.size()));
+        if (!mime_js_str) {
+          return RejectPromiseWithPendingError(cx, result_promise);
+        }
+        JS::RootedValue mime_val(cx, JS::StringValue(mime_js_str));
+        auto *normalized = blob::Blob::normalize_type(cx, mime_val);
+        if (!normalized) {
+          return RejectPromiseWithPendingError(cx, result_promise);
+        }
+        contentType = normalized;
+      }
+    }
+
+    JS::RootedObject blob(cx, blob::Blob::create(cx, std::move(buf), len, contentType));
     if (!blob) {
       return RejectPromiseWithPendingError(cx, result_promise);
     }

--- a/tests/wpt-harness/expectations/fetch/api/body/formdata.any.js.json
+++ b/tests/wpt-harness/expectations/fetch/api/body/formdata.any.js.json
@@ -6,6 +6,6 @@
     "status": "PASS"
   },
   "Consume multipart/form-data headers case-insensitively": {
-    "status": "FAIL"
+    "status": "PASS"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #311.

When calling body.blob() on a Request or Response, the returned Blob was always created with an empty type, regardless of the Content-Type header on the body. This was uncovered by the WPT pass improvements in #312.

Per the Fetch spec 5.2:

▎ If type is non-null, then set object's type to the result of parse a MIME type with type's value.

This fix reads the Content-Type header from the owning request/response when constructing the Blob in parse_body, extracts the MIME type using the existing extract_mime_type helper, and passes the normalized type through Blob::normalize_type before creating the Blob object.

Changes

- builtins/web/blob.h / blob.cpp: Promotes normalize_type from a file-local free function to a public static method on Blob, so request-response.cpp can call it without duplication.
- builtins/web/fetch/request-response.cpp: In parse_body, after constructing the body buffer, looks up the Content-Type header on the owning object, parses the MIME type, normalizes it, and passes it when creating the Blob.
- tests/wpt-harness/expectations/fetch/api/body/formdata.any.js.json: Updates one previously-failing WPT test to PASS (Consume multipart/form-data headers case-insensitively) — the test was failing because it asserted on the Blob.type value derived from the Content-Type header.

Testing

The fix is covered by the WPT test suite. The Consume multipart/form-data headers case-insensitively test in `fetch/api/body/formdata.any.js` now passes.

Running WPT test suite after merging [Response.clone (#312)](https://github.com/bytecodealliance/StarlingMonkey/pull/312) creates a new `fetch/api/body/mime-type.any.js` expectations file.  (20 PASS, 0 FAIL)