### PR TITLE
fix(console): console.assert() logs on failure, not on success

### DIFF
--- a/builtins/web/console.cpp
+++ b/builtins/web/console.cpp
@@ -471,9 +471,9 @@ static bool console_out(JSContext *cx, unsigned argc, JS::Value *vp) {
 static bool assert_(JSContext *cx, unsigned argc, JS::Value *vp) {
   JS::CallArgs args = CallArgsFromVp(argc, vp);
   args.rval().setUndefined();
-  auto condition = args.get(0).toBoolean();
+  auto condition = JS::ToBoolean(args.get(0));
   // 1. If condition is true, return.
-  if (!condition) {
+  if (condition) {
     return true;
   }
 

--- a/tests/e2e/console-assert/console-assert.js
+++ b/tests/e2e/console-assert/console-assert.js
@@ -1,0 +1,16 @@
+// https://console.spec.whatwg.org/#assert
+// console.assert must stay SILENT when the condition is truthy and only log
+// "Assertion failed" when the condition is falsy. The condition is coerced to
+// a boolean, so non-boolean values must be accepted too.
+addEventListener("fetch", (event) => {
+  console.log("a");
+  console.assert(true); // truthy -> silent
+  console.log("b");
+  console.assert(false); // falsy -> logs "Assertion failed"
+  console.log("c");
+  console.assert(1); // truthy non-boolean -> silent
+  console.log("d");
+  console.assert(0); // falsy non-boolean -> logs "Assertion failed"
+  console.log("e");
+  event.respondWith(new Response("ok"));
+});

--- a/tests/e2e/console-assert/expect_serve_stdout.txt
+++ b/tests/e2e/console-assert/expect_serve_stdout.txt
@@ -1,0 +1,7 @@
+stdout [0] :: Log: a
+stdout [0] :: Log: b
+stdout [0] :: Error: Assertion failed
+stdout [0] :: Log: c
+stdout [0] :: Log: d
+stdout [0] :: Error: Assertion failed
+stdout [0] :: Log: e

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -46,6 +46,7 @@ function(integration_tests)
 endfunction()
 
 test_e2e(blob)
+test_e2e(console-assert)
 test_e2e(eventloop-stall)
 test_e2e(headers)
 test_e2e(runtime-err)


### PR DESCRIPTION
console.assert()'s condition was inverted: `if (!condition) return` made it stay silent when the assertion failed and print "Assertion failed" when it passed — the opposite of the cited Console spec, whose step 1 is "If condition is true, return."

Also use JS::ToBoolean() instead of Value::toBoolean(): the latter asserts the argument is already a boolean and crashes a debug build (UB in release) on a non-boolean condition such as console.assert(0). The spec coerces condition to a boolean.

Add an e2e test asserting the serve stdout for truthy/falsy and boolean/non-boolean conditions.